### PR TITLE
Sherlock v1: schema validator with export dashboard + Nostr publishing

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -120,7 +120,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/findings.json docs/index.html
           git diff --cached --quiet || git commit -m "update findings $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          git push
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed (attempt $i/3), rebasing and retrying..."
+            sleep $((i * 2))
+            git pull --rebase origin main
+          done
+          echo "::error::Failed to push after 3 attempts"
+          exit 1
 
       # Save DB for next run
       - name: Save database cache

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,141 @@
+name: Sherlock Scan
+
+on:
+  schedule:
+    # Three scans/day at staggered times to sample different time cohorts.
+    # GitHub cron can drift ±15min, which adds natural jitter on top.
+    - cron: '20 3 * * *'   # ~03:20 UTC
+    - cron: '45 11 * * *'  # ~11:45 UTC
+    - cron: '10 19 * * *'  # ~19:10 UTC
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'Scan window (e.g. 1h, 24h, 7d)'
+        default: '24h'
+      kinds:
+        description: 'Comma-separated kinds (blank = all defaults)'
+        default: ''
+      jitter:
+        description: 'Max random time jitter (e.g. 6h, 0s to disable)'
+        default: '6h'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: false
+
+      - name: Install nak
+        run: go install github.com/fiatjaf/nak@v0.19.0
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Build
+        run: npx tsc
+
+      # Restore DB from previous run (if any)
+      - name: Restore database cache
+        uses: actions/cache/restore@v4
+        id: db-cache
+        with:
+          path: sherlock.db
+          key: sherlock-db-${{ github.run_id }}
+          restore-keys: |
+            sherlock-db-
+
+      - name: Scan relays
+        run: |
+          SINCE="${{ github.event.inputs.since || '12h' }}"
+          KINDS="${{ github.event.inputs.kinds }}"
+          JITTER="${{ github.event.inputs.jitter || '6h' }}"
+
+          ARGS="--since $SINCE --jitter $JITTER"
+          if [ -n "$KINDS" ]; then
+            ARGS="$ARGS --kinds $KINDS"
+          fi
+
+          node dist/index.js scan $ARGS
+
+      - name: Generate reports
+        run: |
+          echo "## Stats" > report.md
+          echo '```' >> report.md
+          node dist/index.js stats >> report.md
+          echo '```' >> report.md
+
+          echo "" >> report.md
+          echo "## Violations by Kind" >> report.md
+          echo '```' >> report.md
+          node dist/index.js report --by kind >> report.md
+          echo '```' >> report.md
+
+          echo "" >> report.md
+          echo "## Violations by Client" >> report.md
+          echo '```' >> report.md
+          node dist/index.js report --by client >> report.md
+          echo '```' >> report.md
+
+          echo "" >> report.md
+          echo "## Top Errors" >> report.md
+          echo '```' >> report.md
+          node dist/index.js report --by error --limit 20 >> report.md
+          echo '```' >> report.md
+
+          cat report.md
+
+      - name: Write job summary
+        run: cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Export findings
+        run: node dist/index.js export
+
+      - name: Publish to Nostr (daily only)
+        if: github.event.schedule == '20 3 * * *' || github.event_name == 'workflow_dispatch'
+        env:
+          NOSTR_SECRET_KEY: ${{ secrets.NOSTR_SECRET_KEY }}
+        run: |
+          if [ -n "$NOSTR_SECRET_KEY" ]; then
+            node dist/index.js export --publish
+          else
+            echo "NOSTR_SECRET_KEY not configured — skipping publish"
+          fi
+
+      - name: Commit findings
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/findings.json docs/index.html
+          git diff --cached --quiet || git commit -m "update findings $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          git push
+
+      # Save DB for next run
+      - name: Save database cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: sherlock.db
+          key: sherlock-db-${{ github.run_id }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sherlock-results-${{ github.run_id }}
+          path: |
+            sherlock.db
+            report.md
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.db
+*.db-wal
+*.db-shm
+report.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+## Commands
+
+- Install: `npm install --legacy-peer-deps` (schemata has peer dep conflicts)
+- Build: `npm run build`
+- Typecheck: `npx tsc --noEmit`
+- Run: `node dist/index.js <command>`
+- No test suite yet. Verify changes compile: `npm run build && npx tsc --noEmit`
+
+## Architecture
+
+```
+src/
+  index.ts              # CLI entry, commander setup
+  config.ts             # Constants: relay lists, kind lists, thresholds
+  types.ts              # Shared interfaces (NostrEvent, ValidationResult, etc.)
+  util.ts               # parseDuration, formatNumber, which()
+  commands/
+    scan.ts             # Fetch events via nak, validate, store
+    report.ts           # Query and display violation reports
+    stats.ts            # Summary statistics
+    export.ts           # Build findings JSON, HTML dashboard, optional Nostr publish
+  fetch/
+    nak.ts              # Spawns `nak` CLI as child process, handles JSONL parsing
+  validate/
+    engine.ts           # AJV validation against schemata schemas
+  attribution/
+    client-tag.ts       # NIP-89 client tag extraction
+  db/
+    index.ts            # SQLite via better-sqlite3, all queries
+```
+
+Four commands (`scan`, `report`, `stats`, `export`) share a SQLite database (`sherlock.db`).
+
+IMPORTANT: The DB schema is the contract between all commands and CI. Schema changes affect every command and break the GitHub Actions cache. ALWAYS add new columns as nullable or with defaults. NEVER drop or rename columns without updating all commands.
+
+## Rules for the HTML dashboard
+
+`export.ts:238 generateHtml()` builds a self-contained HTML page as a TypeScript template literal. The `<script>` block inside runs in the browser, not Node.
+
+When adding content to the dashboard:
+
+1. ALWAYS use the `esc()` function at `export.ts:313` for user-derived text. It is defined inside the template string — do not create a second escaping function.
+2. NEVER use inline `onclick` handlers. Use `data-*` attributes and the delegated click handler at `export.ts:412`. See `export.ts:377` for the `data-copy` pattern.
+3. NEVER embed JSON in the page without `.replace(/</g, '\\u003c')`. See `export.ts:241` for the pattern.
+4. For expandable rows, place `<tr class="detail">` elements immediately after the parent `<tr>`. The expand/collapse handler at `export.ts:396` uses `nextElementSibling` traversal — no `data-parent` attributes or IDs needed.
+
+## Rules for relay fetching
+
+NEVER parallelize relay connections. NEVER increase `DEFAULT_KIND_BATCH_SIZE` beyond 5. NEVER remove or reduce the pause intervals in `config.ts`. Nostr relays ban IPs that send aggressive requests.
+
+Current spacing (`config.ts`):
+- 5 kinds max per REQ filter
+- 5s between paginated pages, 2s between kind batches, 3s between relays
+- Relay and batch order randomized per run
+
+## Rules for child processes
+
+All spawned processes MUST follow the pattern in `nak.ts:14 activeProcs`:
+
+1. Add the process to `activeProcs` immediately after `spawn()` — see `nak.ts:124`
+2. Remove from `activeProcs` in the `close` handler — see `nak.ts:155`
+3. Cap stderr to 10KB — see `nak.ts:145`
+4. Handle exit codes: 0 = success, 3 = relay-level failure (non-fatal, resolve with count), other = reject
+
+## Rules for scan resume
+
+Each kind tracks its own most recent `created_at` as a resume point (`scan.ts:52 perKindSince`). NEVER use a single global timestamp — less-active kinds get skipped when active kinds advance the watermark. See `scan.ts:58-67` for the per-kind loop and `db/index.ts:131 getHighWaterMark(kind)`.
+
+## AJV schema loading
+
+Schemata schemas require preprocessing before AJV compiles them (see `engine.ts:59 stripNestedMetaFields` and `engine.ts:109 stripErrorMessages`):
+
+- Strip nested `$schema` and `$id` fields (keep root `$schema`)
+- Strip `errorMessage` fields (require ajv-errors plugin we don't use)
+- Use `strict: false` (schemas use contains, if/then)
+- NEVER import the `@nostrability/schemata` ESM bundle — it is broken on Node 22+. Use `createRequire` and walk `dist/nips/*.json` directly. See `engine.ts:5-10` for the pattern.
+
+## CI
+
+GitHub Actions runs scan + export 3x/day. The SQLite DB is cached between runs.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Requires [nak](https://github.com/fiatjaf/nak) on PATH for scanning and publishi
 
 ## CI
 
-The GitHub Actions workflow (`sherlock-scan.yml`) runs 3x/day at staggered UTC times. It:
+The GitHub Actions workflow (`scan.yml`) runs 3x/day at staggered UTC times. It:
 
 1. Restores the SQLite DB from cache (incremental scanning)
 2. Scans relays with randomized order and jitter

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Sherlock
+
+Passive schema validator for Nostr events. Fetches events from relays, validates them against [schemata](https://github.com/nostrability/schemata) JSON Schemas, and reports which apps produce malformed blobs.
+
+## How it works
+
+1. **Scan** relays for events across 16 kinds (NIP-01, NIP-02, NIP-17, NIP-23, NIP-47, NIP-57, NIP-59, NIP-65)
+2. **Validate** each event against its JSON Schema using AJV
+3. **Attribute** events to apps via NIP-89 client tags
+4. **Store** results in SQLite for analysis
+5. **Export** findings as JSON + HTML dashboard
+6. **Publish** daily report to Nostr as kind:1 summary + kind:30023 long-form article
+
+CI runs 3x/day via GitHub Actions with relay-friendly rate limiting, batch sizing, and randomized scan order.
+
+## Commands
+
+```bash
+# Scan relays for events and validate
+sherlock scan --since 24h --relays wss://relay.damus.io
+
+# Show database statistics
+sherlock stats
+
+# Show violation reports (by kind, client, error, or recent)
+sherlock report --by kind
+sherlock report --by client --format json
+
+# Export findings to JSON + HTML dashboard
+sherlock export
+
+# Export and publish report to Nostr
+sherlock export --publish
+```
+
+## Output
+
+- **`data/findings.json`** — Machine-readable findings with three views: by kind, by app, error patterns. Git-tracked; changes over time = trend data for free.
+- **`docs/index.html`** — Interactive HTML dashboard with findings inlined (no fetch, no CORS, works as a local file). Served by GitHub Pages.
+- **Nostr notes** — Daily kind:1 highlights + kind:30023 full report published by the [nostrability bot](https://njump.me/npub1g5qtwz2nh9q0mnw555kv787kh6lysds95522gzptre3qpvz9p20s83m80d).
+
+## Setup
+
+```bash
+npm install --legacy-peer-deps
+npx tsc
+```
+
+Requires [nak](https://github.com/fiatjaf/nak) on PATH for scanning and publishing.
+
+## CI
+
+The GitHub Actions workflow (`sherlock-scan.yml`) runs 3x/day at staggered UTC times. It:
+
+1. Restores the SQLite DB from cache (incremental scanning)
+2. Scans relays with randomized order and jitter
+3. Exports `data/findings.json` + `docs/index.html`
+4. Publishes to Nostr (daily, first run only)
+5. Commits findings if changed
+6. Caches DB for next run
+
+To enable Nostr publishing, add `NOSTR_SECRET_KEY` (nsec or hex) to GitHub repo secrets.
+
+## Schema coverage
+
+| NIP | Kinds | Description |
+|-----|-------|-------------|
+| NIP-01 | 0 | Profile metadata |
+| NIP-02 | 3 | Contact list |
+| NIP-17 | 14, 15, 10050 | Direct messages, file messages, DM relay list |
+| NIP-23 | 30023 | Long-form content |
+| NIP-47 | 13194, 23194–23197 | Nostr Wallet Connect |
+| NIP-57 | 9734, 9735 | Zap request, zap receipt |
+| NIP-59 | 13, 1059 | Seal, gift wrap |
+| NIP-65 | 10002 | Relay list metadata |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@nostrability/sherlock",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@nostrability/schemata": "^0.2.6",
         "ajv": "^8.17.1",
@@ -21,6 +22,9 @@
         "@types/node": "^22.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3666 @@
+{
+  "name": "@nostrability/sherlock",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nostrability/sherlock",
+      "version": "0.1.0",
+      "dependencies": {
+        "@nostrability/schemata": "^0.2.6",
+        "ajv": "^8.17.1",
+        "better-sqlite3": "^11.0.0",
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "sherlock": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@glideapps/ts-necessities": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@glideapps/ts-necessities/-/ts-necessities-2.4.0.tgz",
+      "integrity": "sha512-mDC+qosuNa4lxR3ioMBb6CD0XLRsQBplU+zRPUYiMLXKeVPZ6UYphdNG/EGReig0YyfnVlBKZEXl1wzTotYmPA==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@mark.probst/typescript-json-schema": {
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@mark.probst/typescript-json-schema/-/typescript-json-schema-0.55.0.tgz",
+      "integrity": "sha512-jI48mSnRgFQxXiE/UTUCVCpX8lK3wCFKLF1Ss2aEreboKNuLQGt3e0/YFqWVHe/WENxOaqiJvwOz+L/SrN2+qQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^16.9.2",
+        "glob": "^7.1.7",
+        "path-equal": "^1.1.2",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "4.9.4",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "typescript-json-schema": "bin/typescript-json-schema"
+      }
+    },
+    "node_modules/@mark.probst/typescript-json-schema/node_modules/@types/node": {
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "license": "MIT"
+    },
+    "node_modules/@mark.probst/typescript-json-schema/node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@nostrability/schemata": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@nostrability/schemata/-/schemata-0.2.6.tgz",
+      "integrity": "sha512-IKDlISf4v7gqUm1k5nZEbrRKF9bLFMIyVpYKY6Q8y0G5xPoQH8BDa3ADwq+nQW0oos03tZko/z2wNmtlw23fNA==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.7.2",
+        "ajv": "8.17.1",
+        "esbuild-yaml": "^1.2.0",
+        "json-loader": "0.5.7",
+        "quicktype": "23.0.170",
+        "quicktype-core": "23.0.170",
+        "webpack": "5.93.0",
+        "webpack-cli": "5.1.4",
+        "webpack-merge": "6.0.1",
+        "webpack-node-externals": "3.0.0",
+        "yaml": "2.4.5",
+        "yaml-convert": "1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.5.2"
+      }
+    },
+    "node_modules/@nostrability/schemata/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-or-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-3.0.0.tgz",
+      "integrity": "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==",
+      "license": "MIT"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/collection-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/collection-utils/-/collection-utils-1.0.1.tgz",
+      "integrity": "sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.322",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.322.tgz",
+      "integrity": "sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==",
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/envinfo": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
+      "license": "MIT",
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/esbuild-yaml": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/esbuild-yaml/-/esbuild-yaml-1.3.0.tgz",
+      "integrity": "sha512-e7TQfmbB7FSHxz35QMjaaLlJUanutHZ5N3wkxPw4HFgM95AmC5TUp3REOo7F/HbxF/su6pPYhq/Ux+CTROnX2A==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.19.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.11.7.tgz",
+      "integrity": "sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==",
+      "deprecated": "No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support",
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "1.1.3"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/iterall": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
+      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ==",
+      "license": "MIT"
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-equal": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==",
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quicktype": {
+      "version": "23.0.170",
+      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-23.0.170.tgz",
+      "integrity": "sha512-3gFyS7w36ktxrttEv1gMfuUlGairepnSpLN0cp7JVevkKX2N6Uk8AyMlDS2Puki09MY6PB6ch90plThvACtEHA==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "./packages/quicktype-core",
+        "./packages/quicktype-graphql-input",
+        "./packages/quicktype-typescript-input",
+        "./packages/quicktype-vscode"
+      ],
+      "dependencies": {
+        "@glideapps/ts-necessities": "^2.2.3",
+        "chalk": "^4.1.2",
+        "collection-utils": "^1.0.1",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "cross-fetch": "^4.0.0",
+        "graphql": "^0.11.7",
+        "lodash": "^4.17.21",
+        "moment": "^2.30.1",
+        "quicktype-core": "23.0.170",
+        "quicktype-graphql-input": "23.0.170",
+        "quicktype-typescript-input": "23.0.170",
+        "readable-stream": "^4.5.2",
+        "stream-json": "1.8.0",
+        "string-to-stream": "^3.0.1",
+        "typescript": "4.9.5"
+      },
+      "bin": {
+        "quicktype": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/quicktype-core": {
+      "version": "23.0.170",
+      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.170.tgz",
+      "integrity": "sha512-ZsjveG0yJUIijUx4yQshzyQ5EAXKbFSBTQJHnJ+KoSZVxcS+m3GcmDpzrdUIRYMhgLaF11ZGvLSYi5U0xcwemw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@glideapps/ts-necessities": "2.2.3",
+        "browser-or-node": "^3.0.0",
+        "collection-utils": "^1.0.1",
+        "cross-fetch": "^4.0.0",
+        "is-url": "^1.2.4",
+        "js-base64": "^3.7.7",
+        "lodash": "^4.17.21",
+        "pako": "^1.0.6",
+        "pluralize": "^8.0.0",
+        "readable-stream": "4.5.2",
+        "unicode-properties": "^1.4.1",
+        "urijs": "^1.19.1",
+        "wordwrap": "^1.0.0",
+        "yaml": "^2.4.1"
+      }
+    },
+    "node_modules/quicktype-core/node_modules/@glideapps/ts-necessities": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@glideapps/ts-necessities/-/ts-necessities-2.2.3.tgz",
+      "integrity": "sha512-gXi0awOZLHk3TbW55GZLCPP6O+y/b5X1pBXKBVckFONSwF1z1E5ND2BGJsghQFah+pW7pkkyFb2VhUQI2qhL5w==",
+      "license": "MIT"
+    },
+    "node_modules/quicktype-core/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/quicktype-graphql-input": {
+      "version": "23.0.170",
+      "resolved": "https://registry.npmjs.org/quicktype-graphql-input/-/quicktype-graphql-input-23.0.170.tgz",
+      "integrity": "sha512-L0xPKdIFZFChwups9oqJuQw/vwEbRVKBvU9L5jAs0Z/aLyfdsuxDpKGMJXnNWa2yE7NhPX/UDX8ytxn8uc8hdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "collection-utils": "^1.0.1",
+        "graphql": "^0.11.7",
+        "quicktype-core": "23.0.170"
+      }
+    },
+    "node_modules/quicktype-typescript-input": {
+      "version": "23.0.170",
+      "resolved": "https://registry.npmjs.org/quicktype-typescript-input/-/quicktype-typescript-input-23.0.170.tgz",
+      "integrity": "sha512-lckhc//Mc95f/puRFKv4BFs7VpUUJXhw/psh+5ZAMiErxOWgoF87XthGusmaqoXNzjmEy1AVwGgMCG2pp/tJ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mark.probst/typescript-json-schema": "0.55.0",
+        "quicktype-core": "23.0.170",
+        "typescript": "4.9.5"
+      }
+    },
+    "node_modules/quicktype-typescript-input/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/quicktype/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
+      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-to-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-3.0.1.tgz",
+      "integrity": "sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/string-to-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^1.0.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "acorn": "^8.7.1",
+        "acorn-import-attributes": "^1.9.5",
+        "browserslist": "^4.21.10",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.0",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
+        "colorette": "^2.0.14",
+        "commander": "^10.0.1",
+        "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/webpack-cli/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/webpack-node-externals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+      "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yaml-convert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/yaml-convert/-/yaml-convert-1.0.1.tgz",
+      "integrity": "sha512-+LlsBOCJEd2hC+dGiEuHjHxdt7nhhru2lwq+tHWwjEViarR2DYxTKgQwlBzaMUA0K6yaDUrLEk4CuD6QxpHE3Q==",
+      "deprecated": "Command-line tool now included in yaml package",
+      "license": "ISC",
+      "dependencies": {
+        "yaml": "^1.10.2",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "yaml-convert": "cli.js",
+        "yc": "cli.js"
+      }
+    },
+    "node_modules/yaml-convert/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nostrability/sherlock",
+  "version": "0.1.0",
+  "description": "Passive relay listener that validates Nostr events against JSON Schemas and identifies apps producing malformed blobs",
+  "type": "module",
+  "bin": {
+    "sherlock": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "scan": "node dist/index.js scan",
+    "report": "node dist/index.js report",
+    "stats": "node dist/index.js stats"
+  },
+  "dependencies": {
+    "@nostrability/schemata": "^0.2.6",
+    "ajv": "^8.17.1",
+    "better-sqlite3": "^11.0.0",
+    "commander": "^12.0.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "version": "0.1.0",
   "description": "Passive relay listener that validates Nostr events against JSON Schemas and identifies apps producing malformed blobs",
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nostrability/sherlock.git"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist"
+  ],
   "bin": {
     "sherlock": "dist/index.js"
   },

--- a/src/attribution/client-tag.ts
+++ b/src/attribution/client-tag.ts
@@ -1,0 +1,14 @@
+import type { ClientAttribution } from '../types.js';
+
+/**
+ * Extract NIP-89 client tag from event tags (Tier 1 attribution).
+ * Tag format: ["client", "<name>", "<31990:pubkey:d-tag>"]
+ */
+export function extractClientTag(tags: string[][]): ClientAttribution | null {
+  const tag = tags.find(t => t[0] === 'client');
+  if (!tag || !tag[1]) return null;
+  return {
+    name: tag[1],
+    address: tag[2] ?? undefined,
+  };
+}

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -350,15 +350,12 @@ document.querySelectorAll('.tab').forEach(tab => {
     const d = bk[k];
     const topErr = d.top_errors[0];
     const rc = rateClass(d.error_rate);
-    const detailId = 'kind-detail-' + k;
-    html += '<tr data-kind="kind-' + k + '"><td><button type="button" class="expand-btn" aria-expanded="false" aria-controls="' + detailId + '">&#9656;</button>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
+    html += '<tr><td><button type="button" class="expand-btn" aria-expanded="false">&#9656;</button>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
     // Detail rows: per-app breakdown
     const apps = Object.keys(d.by_app).sort((a,b) => d.by_app[b].total - d.by_app[a].total);
-    let kindAppIdx = 0;
     for (const app of apps) {
       const a = d.by_app[app];
-      html += '<tr class="detail" id="' + detailId + '-' + kindAppIdx + '" data-parent="kind-' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
-      kindAppIdx++;
+      html += '<tr class="detail"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
     }
   }
   html += '</tbody></table>';
@@ -371,20 +368,14 @@ document.querySelectorAll('.tab').forEach(tab => {
   const apps = Object.keys(ba).sort((a,b) => ba[b].total_events - ba[a].total_events);
   if (!apps.length) { document.getElementById('panel-app').innerHTML = '<div class="empty">No data</div>'; return; }
   let html = '<table><thead><tr><th>App</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Kinds</th></tr></thead><tbody>';
-  let appIdx = 0;
   for (const app of apps) {
     const d = ba[app];
     const rc = rateClass(d.error_rate);
-    const detailId = 'app-detail-' + appIdx;
-    const parentKey = 'app-' + appIdx;
-    html += '<tr data-app="' + parentKey + '"><td><button type="button" class="expand-btn" aria-expanded="false" aria-controls="' + detailId + '">&#9656;</button>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
+    html += '<tr><td><button type="button" class="expand-btn" aria-expanded="false">&#9656;</button>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
     // Detail rows: violations
-    let violIdx = 0;
     for (const v of d.violations.slice(0, 10)) {
-      html += '<tr class="detail" id="' + detailId + '-' + violIdx + '" data-parent="' + parentKey + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" title="Click to copy ' + id + '" onclick="navigator.clipboard.writeText(\\'' + id + '\\')">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
-      violIdx++;
+      html += '<tr class="detail"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" data-copy="' + id + '" title="Click to copy ' + id + '">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
     }
-    appIdx++;
   }
   html += '</tbody></table>';
   document.getElementById('panel-app').innerHTML = html;
@@ -396,27 +387,32 @@ document.querySelectorAll('.tab').forEach(tab => {
   if (!errs.length) { document.getElementById('panel-errors').innerHTML = '<div class="empty">No errors</div>'; return; }
   let html = '<table><thead><tr><th>Error</th><th>Path</th><th>Message</th><th>Count</th><th>Kinds</th><th>Apps</th><th>Top Pubkeys</th></tr></thead><tbody>';
   for (const e of errs.slice(0, 50)) {
-    html += '<tr><td class="mono">' + esc(e.keyword||'—') + '</td><td class="mono">' + esc(e.path||'/') + '</td><td class="truncate">' + esc(e.message) + '</td><td>' + e.total_count.toLocaleString() + '</td><td>' + e.affected_kinds.map(k => '<span class="badge">' + k + '</span>').join('') + '</td><td>' + e.affected_apps.map(a => '<span class="badge">' + esc(a) + '</span>').join('') + '</td><td class="mono">' + e.top_pubkeys.map(p => '<span class="copy" title="' + p + '" onclick="navigator.clipboard.writeText(\\'' + p + '\\')">' + p.slice(0,8) + '…</span>').join(' ') + '</td></tr>';
+    html += '<tr><td class="mono">' + esc(e.keyword||'—') + '</td><td class="mono">' + esc(e.path||'/') + '</td><td class="truncate">' + esc(e.message) + '</td><td>' + e.total_count.toLocaleString() + '</td><td>' + e.affected_kinds.map(k => '<span class="badge">' + k + '</span>').join('') + '</td><td>' + e.affected_apps.map(a => '<span class="badge">' + esc(a) + '</span>').join('') + '</td><td class="mono">' + e.top_pubkeys.map(p => '<span class="copy" data-copy="' + p + '" title="' + p + '">' + p.slice(0,8) + '…</span>').join(' ') + '</td></tr>';
   }
   html += '</tbody></table>';
   document.getElementById('panel-errors').innerHTML = html;
 })();
 
-// Expand/collapse rows
+// Expand/collapse detail rows via sibling traversal
 document.addEventListener('click', function(e) {
-  const btn = e.target.closest('.expand-btn');
+  var btn = e.target.closest('.expand-btn');
   if (!btn) return;
-  const row = btn.closest('tr');
+  var row = btn.closest('tr');
   if (!row) return;
-  const key = row.dataset.kind || row.dataset.app;
-  const expanded = btn.getAttribute('aria-expanded') === 'true';
+  var expanded = btn.getAttribute('aria-expanded') === 'true';
   btn.setAttribute('aria-expanded', String(!expanded));
   btn.innerHTML = expanded ? '&#9656;' : '&#9662;';
-  var tbody = row.closest('tbody');
-  var details = tbody.querySelectorAll('tr.detail');
-  for (var i = 0; i < details.length; i++) {
-    if (details[i].dataset.parent === key) details[i].classList.toggle('open');
+  var sibling = row.nextElementSibling;
+  while (sibling && sibling.classList.contains('detail')) {
+    sibling.classList.toggle('open');
+    sibling = sibling.nextElementSibling;
   }
+});
+
+// Copy to clipboard via delegated handler
+document.addEventListener('click', function(e) {
+  var el = e.target.closest('[data-copy]');
+  if (el) navigator.clipboard.writeText(el.dataset.copy);
 });
 </script>
 </body>

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,0 +1,605 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  getDb,
+  getEventCountsByKind,
+  getTotalEvents,
+  getAppKindMatrix,
+  getViolationDetails,
+  getTopPubkeysForErrors,
+  getTimeRange,
+  getDistinctRelays,
+} from '../db/index.js';
+import { KIND_NAMES, STATUS_THRESHOLDS, GITHUB_REPO, DEFAULT_KINDS } from '../config.js';
+import { which } from '../util.js';
+
+// --- Types ---
+
+interface KindFindings {
+  name: string;
+  schema_key: string;
+  total: number; valid: number; invalid: number; error_rate: number;
+  top_errors: Array<{ keyword: string | null; path: string | null; message: string; count: number }>;
+  by_app: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string }>;
+}
+
+interface AppFindings {
+  total_events: number; total_valid: number; total_invalid: number; error_rate: number;
+  kinds_published: number[];
+  violations: Array<{
+    kind: number; keyword: string | null; path: string | null;
+    message: string; count: number; sample_event_ids: string[];
+  }>;
+}
+
+interface ErrorPattern {
+  keyword: string | null; path: string | null; message: string;
+  total_count: number; affected_kinds: number[];
+  affected_apps: string[];
+  sample_event_ids: string[];
+  top_pubkeys: string[];
+}
+
+interface Findings {
+  version: number;
+  generated_at: string;
+  scan_coverage: {
+    total_events: number; total_valid: number; total_invalid: number; total_no_schema: number;
+    kinds_scanned: number[];
+    relays: string[];
+    first_event_at: string | null; last_event_at: string | null;
+  };
+  by_kind: Record<string, KindFindings>;
+  by_app: Record<string, AppFindings>;
+  error_patterns: ErrorPattern[];
+}
+
+export interface ExportCommandOptions {
+  outdir?: string;
+  publish?: boolean;
+}
+
+// --- Helpers ---
+
+function computeStatus(total: number, invalid: number): string {
+  if (total < STATUS_THRESHOLDS.MIN_EVENTS) return 'u';
+  if (invalid === 0) return 'y';
+  if (invalid / total <= STATUS_THRESHOLDS.ALMOST_MAX) return 'a';
+  return 'n';
+}
+
+function ts(unix: number | null): string | null {
+  return unix ? new Date(unix * 1000).toISOString() : null;
+}
+
+// --- Build findings ---
+
+function buildFindings(): Findings {
+  getDb(); // ensure initialized
+
+  const total = getTotalEvents();
+  const byKind = getEventCountsByKind();
+  const matrix = getAppKindMatrix();
+  const violations = getViolationDetails();
+  const pubkeyRows = getTopPubkeysForErrors();
+  const timeRange = getTimeRange();
+  const relays = getDistinctRelays();
+
+  // Aggregate totals
+  let totalValid = 0, totalInvalid = 0, totalNoSchema = 0;
+  for (const r of byKind) {
+    totalValid += r.valid;
+    totalInvalid += r.invalid;
+    totalNoSchema += r.no_schema;
+  }
+
+  // Build by_kind
+  const findingsByKind: Record<string, KindFindings> = {};
+  for (const r of byKind) {
+    const validated = r.valid + r.invalid;
+    const errorRate = validated > 0 ? r.invalid / validated : 0;
+
+    // Per-app breakdown for this kind
+    const appBreakdown: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string }> = {};
+    for (const m of matrix) {
+      if (m.kind === r.kind) {
+        const mValidated = m.valid + m.invalid;
+        const mRate = mValidated > 0 ? m.invalid / mValidated : 0;
+        appBreakdown[m.client_name] = {
+          total: m.total, valid: m.valid, invalid: m.invalid,
+          error_rate: Math.round(mRate * 10000) / 10000,
+          status: computeStatus(m.total, m.invalid),
+        };
+      }
+    }
+
+    // Top errors for this kind
+    const kindErrors: Array<{ keyword: string | null; path: string | null; message: string; count: number }> = [];
+    for (const v of violations) {
+      if (v.kind === r.kind) {
+        // Deduplicate across apps — aggregate by keyword+path+message
+        const existing = kindErrors.find(
+          e => e.keyword === v.error_keyword && e.path === v.error_path && e.message === v.error_message
+        );
+        if (existing) {
+          existing.count += v.count;
+        } else {
+          kindErrors.push({ keyword: v.error_keyword, path: v.error_path, message: v.error_message, count: v.count });
+        }
+      }
+    }
+    kindErrors.sort((a, b) => b.count - a.count);
+
+    findingsByKind[String(r.kind)] = {
+      name: KIND_NAMES[r.kind] ?? `Kind ${r.kind}`,
+      schema_key: `kind${r.kind}Schema`,
+      total: r.total, valid: r.valid, invalid: r.invalid,
+      error_rate: Math.round(errorRate * 10000) / 10000,
+      top_errors: kindErrors.slice(0, 10),
+      by_app: appBreakdown,
+    };
+  }
+
+  // Build by_app
+  const findingsByApp: Record<string, AppFindings> = {};
+  for (const m of matrix) {
+    if (!findingsByApp[m.client_name]) {
+      findingsByApp[m.client_name] = {
+        total_events: 0, total_valid: 0, total_invalid: 0, error_rate: 0,
+        kinds_published: [], violations: [],
+      };
+    }
+    const app = findingsByApp[m.client_name];
+    app.total_events += m.total;
+    app.total_valid += m.valid;
+    app.total_invalid += m.invalid;
+    app.kinds_published.push(m.kind);
+  }
+  // Fill violations and compute error rates
+  for (const v of violations) {
+    const app = findingsByApp[v.client_name];
+    if (app) {
+      const samples = v.sample_event_ids ? v.sample_event_ids.split(',') : [];
+      app.violations.push({
+        kind: v.kind, keyword: v.error_keyword, path: v.error_path,
+        message: v.error_message, count: v.count, sample_event_ids: samples,
+      });
+    }
+  }
+  for (const app of Object.values(findingsByApp)) {
+    const validated = app.total_valid + app.total_invalid;
+    app.error_rate = validated > 0 ? Math.round(app.total_invalid / validated * 10000) / 10000 : 0;
+    app.kinds_published.sort((a, b) => a - b);
+    app.violations.sort((a, b) => b.count - a.count);
+  }
+
+  // Build error_patterns
+  // Index pubkeys by error_keyword+error_path
+  const pubkeyIndex = new Map<string, Array<{ pubkey: string; cnt: number }>>();
+  for (const p of pubkeyRows) {
+    const key = `${p.error_keyword ?? ''}\0${p.error_path ?? ''}`;
+    if (!pubkeyIndex.has(key)) pubkeyIndex.set(key, []);
+    pubkeyIndex.get(key)!.push({ pubkey: p.pubkey, cnt: p.cnt });
+  }
+
+  // Aggregate violations into error patterns
+  const patternMap = new Map<string, ErrorPattern>();
+  for (const v of violations) {
+    const key = `${v.error_keyword ?? ''}\0${v.error_path ?? ''}\0${v.error_message}`;
+    if (!patternMap.has(key)) {
+      patternMap.set(key, {
+        keyword: v.error_keyword, path: v.error_path, message: v.error_message,
+        total_count: 0, affected_kinds: [], affected_apps: [],
+        sample_event_ids: [], top_pubkeys: [],
+      });
+    }
+    const p = patternMap.get(key)!;
+    p.total_count += v.count;
+    if (!p.affected_kinds.includes(v.kind)) p.affected_kinds.push(v.kind);
+    if (!p.affected_apps.includes(v.client_name)) p.affected_apps.push(v.client_name);
+    const samples = v.sample_event_ids ? v.sample_event_ids.split(',') : [];
+    for (const s of samples) {
+      if (p.sample_event_ids.length < 3 && !p.sample_event_ids.includes(s)) {
+        p.sample_event_ids.push(s);
+      }
+    }
+  }
+
+  const errorPatterns = [...patternMap.values()];
+  // Fill top pubkeys
+  for (const p of errorPatterns) {
+    const pubkeyKey = `${p.keyword ?? ''}\0${p.path ?? ''}`;
+    const pubs = pubkeyIndex.get(pubkeyKey) ?? [];
+    p.top_pubkeys = pubs.slice(0, 5).map(x => x.pubkey);
+  }
+  errorPatterns.sort((a, b) => b.total_count - a.total_count);
+
+  return {
+    version: 1,
+    generated_at: new Date().toISOString(),
+    scan_coverage: {
+      total_events: total, total_valid: totalValid, total_invalid: totalInvalid, total_no_schema: totalNoSchema,
+      kinds_scanned: byKind.map(r => r.kind).sort((a, b) => a - b),
+      relays,
+      first_event_at: ts(timeRange.first_at),
+      last_event_at: ts(timeRange.last_at),
+    },
+    by_kind: findingsByKind,
+    by_app: findingsByApp,
+    error_patterns: errorPatterns,
+  };
+}
+
+// --- HTML dashboard ---
+
+function generateHtml(findings: Findings): string {
+  const data = JSON.stringify(findings);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sherlock — Nostr Schema Validation Report</title>
+<style>
+:root { --bg: #fff; --fg: #1a1a1a; --muted: #666; --border: #e0e0e0; --hover: #f5f5f5; --accent: #4a90d9; --green: #22863a; --yellow: #b08800; --red: #cb2431; --badge-bg: #f0f0f0; }
+@media(prefers-color-scheme:dark) { :root { --bg: #0d1117; --fg: #c9d1d9; --muted: #8b949e; --border: #30363d; --hover: #161b22; --accent: #58a6ff; --green: #3fb950; --yellow: #d29922; --red: #f85149; --badge-bg: #21262d; } }
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--fg); line-height: 1.5; max-width: 1200px; margin: 0 auto; padding: 20px; }
+h1 { font-size: 1.5rem; margin-bottom: 4px; }
+.subtitle { color: var(--muted); font-size: 0.85rem; margin-bottom: 16px; }
+.subtitle a { color: var(--accent); text-decoration: none; }
+.coverage { display: flex; gap: 24px; flex-wrap: wrap; margin-bottom: 20px; padding: 12px 16px; background: var(--badge-bg); border-radius: 8px; font-size: 0.9rem; }
+.coverage .stat { display: flex; flex-direction: column; }
+.coverage .stat .label { color: var(--muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; }
+.coverage .stat .value { font-weight: 600; font-size: 1.1rem; }
+.tabs { display: flex; gap: 0; border-bottom: 2px solid var(--border); margin-bottom: 16px; }
+.tab { padding: 8px 20px; cursor: pointer; border: none; background: none; color: var(--muted); font-size: 0.9rem; font-weight: 500; border-bottom: 2px solid transparent; margin-bottom: -2px; }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab:hover { color: var(--fg); }
+.panel { display: none; }
+.panel.active { display: block; }
+table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+th { text-align: left; padding: 8px 12px; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; }
+td { padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+tr:hover { background: var(--hover); }
+tr.expandable { cursor: pointer; }
+tr.expandable td:first-child::before { content: "▸ "; color: var(--muted); }
+tr.expandable.open td:first-child::before { content: "▾ "; }
+tr.detail { display: none; }
+tr.detail.open { display: table-row; }
+tr.detail td { padding-left: 32px; background: var(--hover); }
+.status { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+.status-y { background: var(--green); }
+.status-a { background: var(--yellow); }
+.status-n { background: var(--red); }
+.status-u { background: var(--muted); }
+.mono { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.8rem; }
+.badge { display: inline-block; padding: 1px 6px; border-radius: 4px; background: var(--badge-bg); font-size: 0.75rem; margin: 1px; }
+.rate { font-weight: 600; }
+.rate-good { color: var(--green); }
+.rate-warn { color: var(--yellow); }
+.rate-bad { color: var(--red); }
+.truncate { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.copy { cursor: pointer; color: var(--accent); }
+.copy:hover { text-decoration: underline; }
+.empty { text-align: center; padding: 40px; color: var(--muted); }
+</style>
+</head>
+<body>
+<h1>Sherlock — Nostr Schema Validation Report</h1>
+<p class="subtitle">Generated ${findings.generated_at.replace('T', ' ').replace(/\\.\\d+Z$/, ' UTC')} · <a href="${GITHUB_REPO}/tree/main/sherlock">Source</a></p>
+
+<div class="coverage" id="coverage"></div>
+
+<div class="tabs">
+  <button class="tab active" data-tab="kind">By Kind</button>
+  <button class="tab" data-tab="app">By App</button>
+  <button class="tab" data-tab="errors">Errors</button>
+</div>
+
+<div class="panel active" id="panel-kind"></div>
+<div class="panel" id="panel-app"></div>
+<div class="panel" id="panel-errors"></div>
+
+<script>
+const FINDINGS = ${data};
+
+const KIND_NAMES = ${JSON.stringify(KIND_NAMES)};
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function pct(n, t) { return t > 0 ? (n/t*100).toFixed(1) + '%' : '0.0%'; }
+function rateClass(rate) { return rate === 0 ? 'rate-good' : rate <= 0.05 ? 'rate-warn' : 'rate-bad'; }
+function statusDot(s) { return '<span class="status status-' + s + '" title="' + ({y:'clean',a:'almost',n:'broken',u:'unknown'}[s]||s) + '"></span>'; }
+function shortId(id) { return id ? id.slice(0, 8) + '…' : ''; }
+
+// Coverage
+(function() {
+  const c = FINDINGS.scan_coverage;
+  document.getElementById('coverage').innerHTML = [
+    stat('Events', c.total_events.toLocaleString()),
+    stat('Valid', c.total_valid.toLocaleString()),
+    stat('Invalid', c.total_invalid.toLocaleString()),
+    stat('No Schema', c.total_no_schema.toLocaleString()),
+    stat('Kinds', c.kinds_scanned.length),
+    stat('Relays', c.relays.length),
+  ].join('');
+  function stat(label, value) { return '<div class="stat"><span class="label">' + label + '</span><span class="value">' + value + '</span></div>'; }
+})();
+
+// Tabs
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById('panel-' + tab.dataset.tab).classList.add('active');
+  });
+});
+
+// By Kind
+(function() {
+  const bk = FINDINGS.by_kind;
+  const kinds = Object.keys(bk).sort((a,b) => Number(a) - Number(b));
+  if (!kinds.length) { document.getElementById('panel-kind').innerHTML = '<div class="empty">No data</div>'; return; }
+  let html = '<table><thead><tr><th>Kind</th><th>Name</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Top Error</th></tr></thead><tbody>';
+  for (const k of kinds) {
+    const d = bk[k];
+    const topErr = d.top_errors[0];
+    const rc = rateClass(d.error_rate);
+    html += '<tr class="expandable" data-kind="' + k + '"><td>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
+    // Detail rows: per-app breakdown
+    const apps = Object.keys(d.by_app).sort((a,b) => d.by_app[b].total - d.by_app[a].total);
+    for (const app of apps) {
+      const a = d.by_app[app];
+      html += '<tr class="detail" data-parent="' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
+    }
+  }
+  html += '</tbody></table>';
+  document.getElementById('panel-kind').innerHTML = html;
+})();
+
+// By App
+(function() {
+  const ba = FINDINGS.by_app;
+  const apps = Object.keys(ba).sort((a,b) => ba[b].total_events - ba[a].total_events);
+  if (!apps.length) { document.getElementById('panel-app').innerHTML = '<div class="empty">No data</div>'; return; }
+  let html = '<table><thead><tr><th>App</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Kinds</th></tr></thead><tbody>';
+  for (const app of apps) {
+    const d = ba[app];
+    const rc = rateClass(d.error_rate);
+    html += '<tr class="expandable" data-app="' + esc(app) + '"><td>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
+    // Detail rows: violations
+    for (const v of d.violations.slice(0, 10)) {
+      const name = KIND_NAMES[v.kind] || 'kind:' + v.kind;
+      html += '<tr class="detail" data-parent="' + esc(app) + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" title="Click to copy ' + id + '" onclick="navigator.clipboard.writeText(\\'' + id + '\\')">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
+    }
+  }
+  html += '</tbody></table>';
+  document.getElementById('panel-app').innerHTML = html;
+})();
+
+// Errors
+(function() {
+  const errs = FINDINGS.error_patterns;
+  if (!errs.length) { document.getElementById('panel-errors').innerHTML = '<div class="empty">No errors</div>'; return; }
+  let html = '<table><thead><tr><th>Error</th><th>Path</th><th>Message</th><th>Count</th><th>Kinds</th><th>Apps</th><th>Top Pubkeys</th></tr></thead><tbody>';
+  for (const e of errs.slice(0, 50)) {
+    html += '<tr><td class="mono">' + esc(e.keyword||'—') + '</td><td class="mono">' + esc(e.path||'/') + '</td><td class="truncate">' + esc(e.message) + '</td><td>' + e.total_count.toLocaleString() + '</td><td>' + e.affected_kinds.map(k => '<span class="badge">' + k + '</span>').join('') + '</td><td>' + e.affected_apps.map(a => '<span class="badge">' + esc(a) + '</span>').join('') + '</td><td class="mono">' + e.top_pubkeys.map(p => '<span class="copy" title="' + p + '" onclick="navigator.clipboard.writeText(\\'' + p + '\\')">' + p.slice(0,8) + '…</span>').join(' ') + '</td></tr>';
+  }
+  html += '</tbody></table>';
+  document.getElementById('panel-errors').innerHTML = html;
+})();
+
+// Expand/collapse rows
+document.addEventListener('click', function(e) {
+  const row = e.target.closest('tr.expandable');
+  if (!row) return;
+  const key = row.dataset.kind || row.dataset.app;
+  row.classList.toggle('open');
+  row.closest('tbody').querySelectorAll('tr.detail[data-parent="' + key + '"]').forEach(r => r.classList.toggle('open'));
+});
+</script>
+</body>
+</html>`;
+}
+
+// --- Nostr publishing ---
+
+function buildKind1Summary(findings: Findings): string {
+  const c = findings.scan_coverage;
+  const totalValidated = c.total_valid + c.total_invalid;
+  const overallRate = totalValidated > 0 ? (c.total_invalid / totalValidated * 100).toFixed(1) : '0.0';
+
+  let text = `🔍 Sherlock Schema Validation Report\n\n`;
+  text += `${c.total_events.toLocaleString()} events scanned across ${c.kinds_scanned.length} kinds\n`;
+  text += `✅ ${c.total_valid.toLocaleString()} valid · ❌ ${c.total_invalid.toLocaleString()} invalid (${overallRate}% error rate)\n\n`;
+
+  // Top broken kinds
+  const brokenKinds = Object.entries(findings.by_kind)
+    .filter(([, v]) => v.invalid > 0)
+    .sort(([, a], [, b]) => b.error_rate - a.error_rate)
+    .slice(0, 5);
+
+  if (brokenKinds.length > 0) {
+    text += `Top issues:\n`;
+    for (const [kind, data] of brokenKinds) {
+      const ratePct = (data.error_rate * 100).toFixed(1);
+      text += `• kind:${kind} (${data.name}): ${data.invalid} invalid (${ratePct}%)\n`;
+    }
+    text += '\n';
+  }
+
+  // Named apps with issues
+  const namedApps = Object.entries(findings.by_app)
+    .filter(([name, v]) => name !== '_unattributed' && v.total_invalid > 0)
+    .sort(([, a], [, b]) => b.total_invalid - a.total_invalid)
+    .slice(0, 5);
+
+  if (namedApps.length > 0) {
+    text += `Apps with violations:\n`;
+    for (const [name, data] of namedApps) {
+      text += `• ${name}: ${data.total_invalid} invalid of ${data.total_events}\n`;
+    }
+    text += '\n';
+  }
+
+  text += `Full report: ${GITHUB_REPO}/tree/main/sherlock/docs`;
+  return text;
+}
+
+function buildKind30023Content(findings: Findings): string {
+  const c = findings.scan_coverage;
+  const totalValidated = c.total_valid + c.total_invalid;
+  const overallRate = totalValidated > 0 ? (c.total_invalid / totalValidated * 100).toFixed(1) : '0.0';
+
+  let md = `# Sherlock Schema Validation Report\n\n`;
+  md += `*Generated: ${findings.generated_at}*\n\n`;
+  md += `## Scan Coverage\n\n`;
+  md += `| Metric | Value |\n|--------|-------|\n`;
+  md += `| Total Events | ${c.total_events.toLocaleString()} |\n`;
+  md += `| Valid | ${c.total_valid.toLocaleString()} |\n`;
+  md += `| Invalid | ${c.total_invalid.toLocaleString()} (${overallRate}%) |\n`;
+  md += `| No Schema | ${c.total_no_schema.toLocaleString()} |\n`;
+  md += `| Kinds Scanned | ${c.kinds_scanned.join(', ')} |\n\n`;
+
+  // By Kind table
+  md += `## Results by Kind\n\n`;
+  md += `| Kind | Name | Events | Valid | Invalid | Error Rate |\n`;
+  md += `|------|------|--------|-------|---------|------------|\n`;
+  for (const [kind, data] of Object.entries(findings.by_kind).sort(([a], [b]) => Number(a) - Number(b))) {
+    const ratePct = (data.error_rate * 100).toFixed(1);
+    md += `| ${kind} | ${data.name} | ${data.total.toLocaleString()} | ${data.valid.toLocaleString()} | ${data.invalid.toLocaleString()} | ${ratePct}% |\n`;
+  }
+  md += '\n';
+
+  // By App — only named apps
+  const namedApps = Object.entries(findings.by_app)
+    .filter(([name]) => name !== '_unattributed')
+    .sort(([, a], [, b]) => b.total_events - a.total_events);
+
+  if (namedApps.length > 0) {
+    md += `## Results by App\n\n`;
+    md += `| App | Events | Valid | Invalid | Error Rate |\n`;
+    md += `|-----|--------|-------|---------|------------|\n`;
+    for (const [name, data] of namedApps) {
+      const ratePct = (data.error_rate * 100).toFixed(1);
+      md += `| ${name} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
+    }
+    md += '\n';
+  }
+
+  // Top errors
+  const topErrors = findings.error_patterns.slice(0, 20);
+  if (topErrors.length > 0) {
+    md += `## Top Error Patterns\n\n`;
+    md += `| Error | Path | Count | Affected Kinds |\n`;
+    md += `|-------|------|-------|----------------|\n`;
+    for (const e of topErrors) {
+      md += `| ${e.keyword || '—'} | \`${e.path || '/'}\` | ${e.total_count.toLocaleString()} | ${e.affected_kinds.join(', ')} |\n`;
+    }
+    md += '\n';
+  }
+
+  md += `---\n\n`;
+  md += `[Source & methodology](${GITHUB_REPO}/tree/main/sherlock) · Sherlock validates Nostr events against [schemata](https://github.com/nostrability/schemata) JSON Schemas\n`;
+  return md;
+}
+
+async function publishToNostr(findings: Findings): Promise<void> {
+  const nakPath = await which('nak');
+  if (!nakPath) {
+    console.error('  nak not found — skipping Nostr publish');
+    return;
+  }
+
+  const secretKey = process.env.NOSTR_SECRET_KEY;
+  if (!secretKey) {
+    console.error('  NOSTR_SECRET_KEY not set — skipping Nostr publish');
+    return;
+  }
+
+  const publishRelays = [
+    'wss://relay.damus.io',
+    'wss://nos.lol',
+    'wss://relay.nostr.band',
+  ];
+
+  const now = Math.floor(Date.now() / 1000);
+  const dateTag = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  // Kind 1: short summary
+  const kind1Content = buildKind1Summary(findings);
+  console.log('  Publishing kind:1 summary...');
+  try {
+    const kind1Args = [
+      'event',
+      '--sec', secretKey,
+      '-k', '1',
+      '-c', kind1Content,
+      '-t', 't=sherlock',
+      '-t', 't=nostrability',
+      ...publishRelays,
+    ];
+    const result1 = execFileSync(nakPath, kind1Args, { encoding: 'utf-8', timeout: 30000 });
+    console.log('  kind:1 published:', result1.trim().slice(0, 80));
+  } catch (err) {
+    console.error('  kind:1 publish failed:', (err as Error).message);
+  }
+
+  // Kind 30023: long-form article
+  const kind30023Content = buildKind30023Content(findings);
+  const dTag = `sherlock-report-${dateTag}`;
+  console.log('  Publishing kind:30023 report...');
+  try {
+    const kind30023Args = [
+      'event',
+      '--sec', secretKey,
+      '-k', '30023',
+      '-c', kind30023Content,
+      '-d', dTag,
+      '-t', `title=${`Sherlock Report ${dateTag}`}`,
+      '-t', `summary=Nostr schema validation report for ${dateTag}`,
+      '-t', `published_at=${String(now)}`,
+      '-t', 't=sherlock',
+      '-t', 't=nostrability',
+      ...publishRelays,
+    ];
+    const result2 = execFileSync(nakPath, kind30023Args, { encoding: 'utf-8', timeout: 30000 });
+    console.log('  kind:30023 published:', result2.trim().slice(0, 80));
+  } catch (err) {
+    console.error('  kind:30023 publish failed:', (err as Error).message);
+  }
+}
+
+// --- Main export command ---
+
+export async function exportCommand(opts: ExportCommandOptions): Promise<void> {
+  const outdir = opts.outdir ?? '.';
+
+  console.log('Building findings...');
+  const findings = buildFindings();
+
+  // Write JSON
+  const jsonPath = resolve(outdir, 'data', 'findings.json');
+  mkdirSync(dirname(jsonPath), { recursive: true });
+  writeFileSync(jsonPath, JSON.stringify(findings, null, 2) + '\n');
+  console.log(`  Wrote ${jsonPath}`);
+
+  // Write HTML
+  const htmlPath = resolve(outdir, 'docs', 'index.html');
+  mkdirSync(dirname(htmlPath), { recursive: true });
+  writeFileSync(htmlPath, generateHtml(findings));
+  console.log(`  Wrote ${htmlPath}`);
+
+  // Summary
+  const c = findings.scan_coverage;
+  console.log(`\nScan coverage: ${c.total_events.toLocaleString()} events, ${c.total_valid.toLocaleString()} valid, ${c.total_invalid.toLocaleString()} invalid`);
+  console.log(`Kinds: ${Object.keys(findings.by_kind).length} | Apps: ${Object.keys(findings.by_app).length} | Error patterns: ${findings.error_patterns.length}`);
+
+  // Publish to Nostr (if requested)
+  if (opts.publish) {
+    console.log('\nPublishing to Nostr...');
+    await publishToNostr(findings);
+  }
+}

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -175,10 +175,10 @@ function buildFindings(): Findings {
   }
 
   // Build error_patterns
-  // Index pubkeys by error_keyword+error_path
+  // Index pubkeys by error_keyword+error_path+error_message (aligned with patternMap key)
   const pubkeyIndex = new Map<string, Array<{ pubkey: string; cnt: number }>>();
   for (const p of pubkeyRows) {
-    const key = `${p.error_keyword ?? ''}\0${p.error_path ?? ''}`;
+    const key = `${p.error_keyword ?? ''}\0${p.error_path ?? ''}\0${p.error_message}`;
     if (!pubkeyIndex.has(key)) pubkeyIndex.set(key, []);
     pubkeyIndex.get(key)!.push({ pubkey: p.pubkey, cnt: p.cnt });
   }
@@ -207,9 +207,9 @@ function buildFindings(): Findings {
   }
 
   const errorPatterns = [...patternMap.values()];
-  // Fill top pubkeys
+  // Fill top pubkeys (keyed by keyword+path+message, matching patternMap)
   for (const p of errorPatterns) {
-    const pubkeyKey = `${p.keyword ?? ''}\0${p.path ?? ''}`;
+    const pubkeyKey = `${p.keyword ?? ''}\0${p.path ?? ''}\0${p.message}`;
     const pubs = pubkeyIndex.get(pubkeyKey) ?? [];
     p.top_pubkeys = pubs.slice(0, 5).map(x => x.pubkey);
   }
@@ -307,7 +307,7 @@ tr.detail td { padding-left: 32px; background: var(--hover); }
 <script>
 const FINDINGS = ${data};
 
-const KIND_NAMES = ${JSON.stringify(KIND_NAMES)};
+const KIND_NAMES = ${JSON.stringify(KIND_NAMES).replace(/</g, '\\u003c')};
 
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 function pct(n, t) { return t > 0 ? (n/t*100).toFixed(1) + '%' : '0.0%'; }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -94,14 +94,14 @@ function buildFindings(): Findings {
     totalNoSchema += r.no_schema;
   }
 
-  // Build by_kind
-  const findingsByKind: Record<string, KindFindings> = {};
+  // Build by_kind (use Object.create(null) to prevent prototype pollution from client-controlled keys)
+  const findingsByKind: Record<string, KindFindings> = Object.create(null);
   for (const r of byKind) {
     const validated = r.valid + r.invalid;
     const errorRate = validated > 0 ? r.invalid / validated : 0;
 
     // Per-app breakdown for this kind
-    const appBreakdown: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string }> = {};
+    const appBreakdown: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string }> = Object.create(null);
     for (const m of matrix) {
       if (m.kind === r.kind) {
         const mValidated = m.valid + m.invalid;
@@ -142,7 +142,7 @@ function buildFindings(): Findings {
   }
 
   // Build by_app
-  const findingsByApp: Record<string, AppFindings> = {};
+  const findingsByApp: Record<string, AppFindings> = Object.create(null);
   for (const m of matrix) {
     if (!findingsByApp[m.client_name]) {
       findingsByApp[m.client_name] = {
@@ -234,7 +234,9 @@ function buildFindings(): Findings {
 // --- HTML dashboard ---
 
 function generateHtml(findings: Findings): string {
-  const data = JSON.stringify(findings);
+  // Escape </script> sequences to prevent XSS breakout from inline <script> tag.
+  // Also escape <!-- to prevent HTML comment injection.
+  const data = JSON.stringify(findings).replace(/</g, '\\u003c');
   return `<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -354,9 +354,11 @@ document.querySelectorAll('.tab').forEach(tab => {
     html += '<tr data-kind="kind-' + k + '"><td><button type="button" class="expand-btn" aria-expanded="false" aria-controls="' + detailId + '">&#9656;</button>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
     // Detail rows: per-app breakdown
     const apps = Object.keys(d.by_app).sort((a,b) => d.by_app[b].total - d.by_app[a].total);
+    let kindAppIdx = 0;
     for (const app of apps) {
       const a = d.by_app[app];
-      html += '<tr class="detail" id="' + detailId + '" data-parent="kind-' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
+      html += '<tr class="detail" id="' + detailId + '-' + kindAppIdx + '" data-parent="kind-' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
+      kindAppIdx++;
     }
   }
   html += '</tbody></table>';
@@ -377,8 +379,10 @@ document.querySelectorAll('.tab').forEach(tab => {
     const parentKey = 'app-' + appIdx;
     html += '<tr data-app="' + parentKey + '"><td><button type="button" class="expand-btn" aria-expanded="false" aria-controls="' + detailId + '">&#9656;</button>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
     // Detail rows: violations
+    let violIdx = 0;
     for (const v of d.violations.slice(0, 10)) {
-      html += '<tr class="detail" id="' + detailId + '" data-parent="' + parentKey + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" title="Click to copy ' + id + '" onclick="navigator.clipboard.writeText(\\'' + id + '\\')">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
+      html += '<tr class="detail" id="' + detailId + '-' + violIdx + '" data-parent="' + parentKey + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" title="Click to copy ' + id + '" onclick="navigator.clipboard.writeText(\\'' + id + '\\')">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
+      violIdx++;
     }
     appIdx++;
   }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -288,7 +288,7 @@ tr.detail td { padding-left: 32px; background: var(--hover); }
 </head>
 <body>
 <h1>Sherlock — Nostr Schema Validation Report</h1>
-<p class="subtitle">Generated ${findings.generated_at.replace('T', ' ').replace(/\\.\\d+Z$/, ' UTC')} · <a href="${GITHUB_REPO}/tree/main/sherlock">Source</a></p>
+<p class="subtitle">Generated ${findings.generated_at.replace('T', ' ').replace(/\.\d+Z$/, ' UTC')} · <a href="${GITHUB_REPO}">Source</a></p>
 
 <div class="coverage" id="coverage"></div>
 
@@ -444,7 +444,7 @@ function buildKind1Summary(findings: Findings): string {
     text += '\n';
   }
 
-  text += `Full report: ${GITHUB_REPO}/tree/main/sherlock/docs`;
+  text += `Full report: ${GITHUB_REPO}/tree/main/docs`;
   return text;
 }
 
@@ -502,7 +502,7 @@ function buildKind30023Content(findings: Findings): string {
   }
 
   md += `---\n\n`;
-  md += `[Source & methodology](${GITHUB_REPO}/tree/main/sherlock) · Sherlock validates Nostr events against [schemata](https://github.com/nostrability/schemata) JSON Schemas\n`;
+  md += `[Source & methodology](${GITHUB_REPO}) · Sherlock validates Nostr events against [schemata](https://github.com/nostrability/schemata) JSON Schemas\n`;
   return md;
 }
 
@@ -528,20 +528,22 @@ async function publishToNostr(findings: Findings): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   const dateTag = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
 
+  // Pass secret key via env (nak reads $NOSTR_SECRET_KEY automatically)
+  const nakEnv = { ...process.env, NOSTR_SECRET_KEY: secretKey };
+
   // Kind 1: short summary
   const kind1Content = buildKind1Summary(findings);
   console.log('  Publishing kind:1 summary...');
   try {
     const kind1Args = [
       'event',
-      '--sec', secretKey,
       '-k', '1',
       '-c', kind1Content,
       '-t', 't=sherlock',
       '-t', 't=nostrability',
       ...publishRelays,
     ];
-    const result1 = execFileSync(nakPath, kind1Args, { encoding: 'utf-8', timeout: 30000 });
+    const result1 = execFileSync(nakPath, kind1Args, { encoding: 'utf-8', timeout: 30000, env: nakEnv });
     console.log('  kind:1 published:', result1.trim().slice(0, 80));
   } catch (err) {
     console.error('  kind:1 publish failed:', (err as Error).message);
@@ -554,7 +556,6 @@ async function publishToNostr(findings: Findings): Promise<void> {
   try {
     const kind30023Args = [
       'event',
-      '--sec', secretKey,
       '-k', '30023',
       '-c', kind30023Content,
       '-d', dTag,
@@ -565,7 +566,7 @@ async function publishToNostr(findings: Findings): Promise<void> {
       '-t', 't=nostrability',
       ...publishRelays,
     ];
-    const result2 = execFileSync(nakPath, kind30023Args, { encoding: 'utf-8', timeout: 30000 });
+    const result2 = execFileSync(nakPath, kind30023Args, { encoding: 'utf-8', timeout: 30000, env: nakEnv });
     console.log('  kind:30023 published:', result2.trim().slice(0, 80));
   } catch (err) {
     console.error('  kind:30023 publish failed:', (err as Error).message);

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -62,10 +62,11 @@ export interface ExportCommandOptions {
 
 // --- Helpers ---
 
-function computeStatus(total: number, invalid: number): string {
-  if (total < STATUS_THRESHOLDS.MIN_EVENTS) return 'u';
+function computeStatus(valid: number, invalid: number): string {
+  const validated = valid + invalid;
+  if (validated < STATUS_THRESHOLDS.MIN_EVENTS) return 'u';
   if (invalid === 0) return 'y';
-  if (invalid / total <= STATUS_THRESHOLDS.ALMOST_MAX) return 'a';
+  if (invalid / validated <= STATUS_THRESHOLDS.ALMOST_MAX) return 'a';
   return 'n';
 }
 
@@ -109,7 +110,7 @@ function buildFindings(): Findings {
         appBreakdown[m.client_name] = {
           total: m.total, valid: m.valid, invalid: m.invalid,
           error_rate: Math.round(mRate * 10000) / 10000,
-          status: computeStatus(m.total, m.invalid),
+          status: computeStatus(m.valid, m.invalid),
         };
       }
     }
@@ -418,7 +419,18 @@ document.addEventListener('click', function(e) {
 </html>`;
 }
 
-// --- Nostr publishing ---
+// --- Nostr publishing helpers ---
+
+/** Strip newlines and control chars from relay-derived text for plain-text notes. */
+function sanitizeText(s: string): string {
+  return s.replace(/[\r\n\t]+/g, ' ').trim();
+}
+
+/** Escape pipe and strip newlines for markdown table cells. */
+function mdCell(s: string): string {
+  return s.replace(/[\r\n\t]+/g, ' ').replace(/\|/g, '\\|').trim();
+}
+
 
 function buildKind1Summary(findings: Findings): string {
   const c = findings.scan_coverage;
@@ -453,7 +465,7 @@ function buildKind1Summary(findings: Findings): string {
   if (namedApps.length > 0) {
     text += `Apps with violations:\n`;
     for (const [name, data] of namedApps) {
-      text += `• ${name}: ${data.total_invalid} invalid of ${data.total_events}\n`;
+      text += `• ${sanitizeText(name)}: ${data.total_invalid} invalid of ${data.total_events}\n`;
     }
     text += '\n';
   }
@@ -498,7 +510,7 @@ function buildKind30023Content(findings: Findings): string {
     md += `|-----|--------|-------|---------|------------|\n`;
     for (const [name, data] of namedApps) {
       const ratePct = (data.error_rate * 100).toFixed(1);
-      md += `| ${name} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
+      md += `| ${mdCell(name)} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
     }
     md += '\n';
   }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -11,7 +11,7 @@ import {
   getTimeRange,
   getDistinctRelays,
 } from '../db/index.js';
-import { KIND_NAMES, STATUS_THRESHOLDS, GITHUB_REPO, DEFAULT_KINDS } from '../config.js';
+import { KIND_NAMES, STATUS_THRESHOLDS, GITHUB_REPO, DEFAULT_KINDS, PUBLISH_RELAYS } from '../config.js';
 import { which } from '../util.js';
 
 // --- Types ---
@@ -545,12 +545,6 @@ async function publishToNostr(findings: Findings): Promise<void> {
     return;
   }
 
-  const publishRelays = [
-    'wss://relay.damus.io',
-    'wss://nos.lol',
-    'wss://relay.nostr.band',
-  ];
-
   const now = Math.floor(Date.now() / 1000);
   const dateTag = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
 
@@ -567,7 +561,7 @@ async function publishToNostr(findings: Findings): Promise<void> {
       '-c', kind1Content,
       '-t', 't=sherlock',
       '-t', 't=nostrability',
-      ...publishRelays,
+      ...PUBLISH_RELAYS,
     ];
     const result1 = execFileSync(nakPath, kind1Args, { encoding: 'utf-8', timeout: 30000, env: nakEnv });
     console.log('  kind:1 published:', result1.trim().slice(0, 80));
@@ -590,7 +584,7 @@ async function publishToNostr(findings: Findings): Promise<void> {
       '-t', `published_at=${String(now)}`,
       '-t', 't=sherlock',
       '-t', 't=nostrability',
-      ...publishRelays,
+      ...PUBLISH_RELAYS,
     ];
     const result2 = execFileSync(nakPath, kind30023Args, { encoding: 'utf-8', timeout: 30000, env: nakEnv });
     console.log('  kind:30023 published:', result2.trim().slice(0, 80));

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -220,7 +220,8 @@ function buildFindings(): Findings {
     generated_at: new Date().toISOString(),
     scan_coverage: {
       total_events: total, total_valid: totalValid, total_invalid: totalInvalid, total_no_schema: totalNoSchema,
-      kinds_scanned: byKind.map(r => r.kind).sort((a, b) => a - b),
+      // Include all configured kinds (not just those with events) so zero-hit kinds are visible
+      kinds_scanned: [...new Set([...DEFAULT_KINDS, ...byKind.map(r => r.kind)])].sort((a, b) => a - b),
       relays,
       first_event_at: ts(timeRange.first_at),
       last_event_at: ts(timeRange.last_at),
@@ -265,12 +266,11 @@ table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
 th { text-align: left; padding: 8px 12px; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; }
 td { padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
 tr:hover { background: var(--hover); }
-tr.expandable { cursor: pointer; }
-tr.expandable td:first-child::before { content: "▸ "; color: var(--muted); }
-tr.expandable.open td:first-child::before { content: "▾ "; }
 tr.detail { display: none; }
 tr.detail.open { display: table-row; }
 tr.detail td { padding-left: 32px; background: var(--hover); }
+.expand-btn { background: none; border: none; cursor: pointer; color: var(--muted); font-size: 0.85rem; padding: 0 4px 0 0; vertical-align: middle; }
+.expand-btn:hover { color: var(--fg); }
 .status { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
 .status-y { background: var(--green); }
 .status-a { background: var(--yellow); }
@@ -349,12 +349,13 @@ document.querySelectorAll('.tab').forEach(tab => {
     const d = bk[k];
     const topErr = d.top_errors[0];
     const rc = rateClass(d.error_rate);
-    html += '<tr class="expandable" data-kind="' + k + '"><td>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
+    const detailId = 'kind-detail-' + k;
+    html += '<tr data-kind="kind-' + k + '"><td><button type="button" class="expand-btn" aria-expanded="false" aria-controls="' + detailId + '">&#9656;</button>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
     // Detail rows: per-app breakdown
     const apps = Object.keys(d.by_app).sort((a,b) => d.by_app[b].total - d.by_app[a].total);
     for (const app of apps) {
       const a = d.by_app[app];
-      html += '<tr class="detail" data-parent="' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
+      html += '<tr class="detail" id="' + detailId + '" data-parent="kind-' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
     }
   }
   html += '</tbody></table>';
@@ -367,15 +368,18 @@ document.querySelectorAll('.tab').forEach(tab => {
   const apps = Object.keys(ba).sort((a,b) => ba[b].total_events - ba[a].total_events);
   if (!apps.length) { document.getElementById('panel-app').innerHTML = '<div class="empty">No data</div>'; return; }
   let html = '<table><thead><tr><th>App</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Kinds</th></tr></thead><tbody>';
+  let appIdx = 0;
   for (const app of apps) {
     const d = ba[app];
     const rc = rateClass(d.error_rate);
-    html += '<tr class="expandable" data-app="' + esc(app) + '"><td>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
+    const detailId = 'app-detail-' + appIdx;
+    const parentKey = 'app-' + appIdx;
+    html += '<tr data-app="' + parentKey + '"><td><button type="button" class="expand-btn" aria-expanded="false" aria-controls="' + detailId + '">&#9656;</button>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
     // Detail rows: violations
     for (const v of d.violations.slice(0, 10)) {
-      const name = KIND_NAMES[v.kind] || 'kind:' + v.kind;
-      html += '<tr class="detail" data-parent="' + esc(app) + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" title="Click to copy ' + id + '" onclick="navigator.clipboard.writeText(\\'' + id + '\\')">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
+      html += '<tr class="detail" id="' + detailId + '" data-parent="' + parentKey + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" title="Click to copy ' + id + '" onclick="navigator.clipboard.writeText(\\'' + id + '\\')">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
     }
+    appIdx++;
   }
   html += '</tbody></table>';
   document.getElementById('panel-app').innerHTML = html;
@@ -395,11 +399,19 @@ document.querySelectorAll('.tab').forEach(tab => {
 
 // Expand/collapse rows
 document.addEventListener('click', function(e) {
-  const row = e.target.closest('tr.expandable');
+  const btn = e.target.closest('.expand-btn');
+  if (!btn) return;
+  const row = btn.closest('tr');
   if (!row) return;
   const key = row.dataset.kind || row.dataset.app;
-  row.classList.toggle('open');
-  row.closest('tbody').querySelectorAll('tr.detail[data-parent="' + key + '"]').forEach(r => r.classList.toggle('open'));
+  const expanded = btn.getAttribute('aria-expanded') === 'true';
+  btn.setAttribute('aria-expanded', String(!expanded));
+  btn.innerHTML = expanded ? '&#9656;' : '&#9662;';
+  var tbody = row.closest('tbody');
+  var details = tbody.querySelectorAll('tr.detail');
+  for (var i = 0; i < details.length; i++) {
+    if (details[i].dataset.parent === key) details[i].classList.toggle('open');
+  }
 });
 </script>
 </body>

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -17,7 +17,8 @@ export function reportCommand(opts: ReportCommandOptions): void {
 
   const groupBy = opts.by || 'kind';
   const format = opts.format || 'table';
-  const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+  const parsed = opts.limit ? parseInt(opts.limit, 10) : NaN;
+  const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 
   switch (groupBy) {
     case 'kind':
@@ -144,6 +145,14 @@ function reportRecent(format: string, limit?: number): void {
 
   if (format === 'json') {
     console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (format === 'csv') {
+    console.log('event_id,kind,client_name,error_message');
+    for (const row of rows) {
+      console.log(`${row.event_id},${row.kind},${row.client_name ?? '-'},${JSON.stringify(row.error_message)}`);
+    }
     return;
   }
 

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,0 +1,159 @@
+import {
+  getViolationsByKind,
+  getViolationsByClient,
+  getViolationsByError,
+  getRecentViolations,
+  getDb,
+} from '../db/index.js';
+
+interface ReportCommandOptions {
+  by?: string;
+  format?: string;
+  limit?: string;
+}
+
+export function reportCommand(opts: ReportCommandOptions): void {
+  getDb(); // ensure initialized
+
+  const groupBy = opts.by || 'kind';
+  const format = opts.format || 'table';
+  const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+
+  switch (groupBy) {
+    case 'kind':
+      reportByKind(format);
+      break;
+    case 'client':
+      reportByClient(format);
+      break;
+    case 'error':
+      reportByError(format, limit);
+      break;
+    case 'recent':
+      reportRecent(format, limit);
+      break;
+    default:
+      console.error(`Unknown grouping: ${groupBy}. Use: kind, client, error, recent`);
+      process.exit(1);
+  }
+}
+
+function reportByKind(format: string): void {
+  const rows = getViolationsByKind();
+  if (rows.length === 0) {
+    console.log('No violations found.');
+    return;
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (format === 'csv') {
+    console.log('kind,schema_key,error_keyword,error_count');
+    for (const row of rows) {
+      console.log(`${row.kind},${row.schema_key},${row.error_keyword ?? ''},${row.error_count}`);
+    }
+    return;
+  }
+
+  // Table format
+  console.log('\nViolations by Kind\n');
+  console.log(`${'Kind'.padEnd(8)} ${'Schema'.padEnd(25)} ${'Error Type'.padEnd(20)} ${'Count'.padStart(8)}`);
+  console.log('-'.repeat(65));
+  for (const row of rows) {
+    console.log(
+      `${String(row.kind).padEnd(8)} ${row.schema_key.padEnd(25)} ${(row.error_keyword ?? '-').padEnd(20)} ${String(row.error_count).padStart(8)}`
+    );
+  }
+}
+
+function reportByClient(format: string): void {
+  const rows = getViolationsByClient();
+  if (rows.length === 0) {
+    console.log('No client-attributed events found.');
+    return;
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (format === 'csv') {
+    console.log('client_name,total_events,invalid_events,violation_count');
+    for (const row of rows) {
+      console.log(`${row.client_name ?? 'unknown'},${row.total_events},${row.invalid_events},${row.violation_count}`);
+    }
+    return;
+  }
+
+  // Table format
+  console.log('\nViolations by Client\n');
+  console.log(`${'Client'.padEnd(25)} ${'Events'.padStart(8)} ${'Invalid'.padStart(8)} ${'Violations'.padStart(12)}`);
+  console.log('-'.repeat(57));
+  for (const row of rows) {
+    console.log(
+      `${(row.client_name ?? 'unknown').padEnd(25)} ${String(row.total_events).padStart(8)} ${String(row.invalid_events).padStart(8)} ${String(row.violation_count).padStart(12)}`
+    );
+  }
+}
+
+function reportByError(format: string, limit?: number): void {
+  const rows = getViolationsByError();
+  const display = limit ? rows.slice(0, limit) : rows;
+
+  if (display.length === 0) {
+    console.log('No violations found.');
+    return;
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify(display, null, 2));
+    return;
+  }
+
+  if (format === 'csv') {
+    console.log('error_keyword,error_path,error_message,count');
+    for (const row of display) {
+      console.log(`${row.error_keyword ?? ''},${row.error_path ?? ''},${JSON.stringify(row.error_message)},${row.count}`);
+    }
+    return;
+  }
+
+  // Table format
+  console.log('\nViolations by Error\n');
+  console.log(`${'Keyword'.padEnd(18)} ${'Path'.padEnd(25)} ${'Message'.padEnd(40)} ${'Count'.padStart(8)}`);
+  console.log('-'.repeat(95));
+  for (const row of display) {
+    const msg = row.error_message.length > 38 ? row.error_message.slice(0, 35) + '...' : row.error_message;
+    console.log(
+      `${(row.error_keyword ?? '-').padEnd(18)} ${(row.error_path ?? '/').padEnd(25)} ${msg.padEnd(40)} ${String(row.count).padStart(8)}`
+    );
+  }
+}
+
+function reportRecent(format: string, limit?: number): void {
+  const rows = getRecentViolations(limit ?? 20);
+
+  if (rows.length === 0) {
+    console.log('No violations found.');
+    return;
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  console.log('\nRecent Violations\n');
+  console.log(`${'Event ID'.padEnd(12)} ${'Kind'.padEnd(8)} ${'Client'.padEnd(20)} ${'Error'.padEnd(40)}`);
+  console.log('-'.repeat(84));
+  for (const row of rows) {
+    const msg = row.error_message.length > 38 ? row.error_message.slice(0, 35) + '...' : row.error_message;
+    console.log(
+      `${row.event_id.slice(0, 10).padEnd(12)} ${String(row.kind).padEnd(8)} ${(row.client_name ?? '-').padEnd(20)} ${msg.padEnd(40)}`
+    );
+  }
+}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -94,7 +94,8 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     fetched: 0,
     duplicates: 0,
     newEvents: 0,
-    violations: 0,
+    invalidEvents: 0,
+    violationErrors: 0,
     rateLimits: 0,
   };
   const rateLimitEvents: RateLimitEvent[] = [];
@@ -135,7 +136,8 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
       } else {
         progress.newEvents++;
         if (validation.valid === false) {
-          progress.violations += validation.errors.length;
+          progress.invalidEvents++;
+          progress.violationErrors += validation.errors.length;
         }
       }
 
@@ -156,7 +158,8 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   console.log(`  Total fetched:  ${formatNumber(progress.fetched)}`);
   console.log(`  New events:     ${formatNumber(progress.newEvents)}`);
   console.log(`  Duplicates:     ${formatNumber(progress.duplicates)}`);
-  console.log(`  Violations:     ${formatNumber(progress.violations)}`);
+  console.log(`  Invalid events: ${formatNumber(progress.invalidEvents)}`);
+  console.log(`  Violation errs: ${formatNumber(progress.violationErrors)}`);
 
   if (progress.rateLimits > 0) {
     console.log('');

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -4,7 +4,7 @@ import { validateEvent, checkSchemaAvailability } from '../validate/engine.js';
 import { extractClientTag } from '../attribution/client-tag.js';
 import { storeEvent, getHighWaterMark, getDb } from '../db/index.js';
 import { parseDuration, formatNumber } from '../util.js';
-import type { ScanProgress, RateLimitEvent } from '../types.js';
+import type { RateLimitEvent } from '../types.js';
 
 interface ScanCommandOptions {
   kinds?: string;
@@ -77,10 +77,10 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   console.log(`  Since: ${sinceDate} (jitter: -${Math.floor(jitterApplied / 60)}m)`);
   console.log('');
 
-  const progress: ScanProgress = {
+  const progress = {
     fetched: 0,
     duplicates: 0,
-    validated: 0,
+    newEvents: 0,
     violations: 0,
     rateLimits: 0,
   };
@@ -109,17 +109,17 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
       rateLimitEvents.push(event);
       console.error(`    !! RATE LIMITED by ${event.relay}: ${event.reason}`);
     },
-    onEvent: (event) => {
+    onEvent: (event, relay) => {
       progress.fetched++;
 
       const validation = validateEvent(event);
       const client = extractClientTag(event.tags);
-      const isNew = storeEvent(event, validation, client);
+      const isNew = storeEvent(event, validation, client, relay);
 
       if (!isNew) {
         progress.duplicates++;
       } else {
-        progress.validated++;
+        progress.newEvents++;
         if (validation.valid === false) {
           progress.violations += validation.errors.length;
         }
@@ -140,7 +140,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   console.log('');
   console.log('Results:');
   console.log(`  Total fetched:  ${formatNumber(progress.fetched)}`);
-  console.log(`  New events:     ${formatNumber(progress.validated)}`);
+  console.log(`  New events:     ${formatNumber(progress.newEvents)}`);
   console.log(`  Duplicates:     ${formatNumber(progress.duplicates)}`);
   console.log(`  Violations:     ${formatNumber(progress.violations)}`);
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -41,7 +41,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
 
   // Parse relays
   const relays = opts.relays
-    ? opts.relays.split(',').map(r => r.trim())
+    ? opts.relays.split(',').map(r => r.trim()).filter(Boolean)
     : DEFAULT_RELAYS;
 
   // Determine since timestamp.

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -44,14 +44,27 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     ? opts.relays.split(',').map(r => r.trim())
     : DEFAULT_RELAYS;
 
-  // Determine since timestamp
+  // Determine since timestamp.
+  // When no --since is given, use per-kind high-water marks so that each kind
+  // resumes from its own last-seen timestamp. This prevents a kind with recent
+  // activity from advancing the watermark past kinds that haven't been scanned.
   let since: number;
+  let perKindSince: Map<number, number> | null = null;
   if (opts.since) {
     const duration = parseDuration(opts.since);
     since = Math.floor(Date.now() / 1000) - duration;
   } else {
-    const hwm = getHighWaterMark();
-    since = hwm ?? Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
+    const fallback = Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
+    const kindTimestamps = new Map<number, number>();
+    let minSince = Infinity;
+    for (const kind of kinds) {
+      const hwm = getHighWaterMark(kind);
+      const ts = hwm ?? fallback;
+      kindTimestamps.set(kind, ts);
+      if (ts < minSince) minSince = ts;
+    }
+    since = minSince === Infinity ? fallback : minSince;
+    perKindSince = kindTimestamps;
   }
 
   // Apply time jitter: randomly look further back by up to 6 hours
@@ -95,6 +108,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     kinds,
     relays,
     since,
+    perKindSince: perKindSince ?? undefined,
     onRelayStart: (relay, index, total) => {
       console.log(`  [relay ${index + 1}/${total}] ${relay}`);
     },

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,0 +1,156 @@
+import { DEFAULT_RELAYS, DEFAULT_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE } from '../config.js';
+import { fetchEvents, checkNak } from '../fetch/nak.js';
+import { validateEvent, checkSchemaAvailability } from '../validate/engine.js';
+import { extractClientTag } from '../attribution/client-tag.js';
+import { storeEvent, getHighWaterMark, getDb } from '../db/index.js';
+import { parseDuration, formatNumber } from '../util.js';
+import type { ScanProgress, RateLimitEvent } from '../types.js';
+
+interface ScanCommandOptions {
+  kinds?: string;
+  relays?: string;
+  since?: string;
+  jitter?: string;
+}
+
+/**
+ * Add random jitter to a timestamp.
+ * Returns a timestamp shifted by a random amount within [-jitterSeconds, 0].
+ * This ensures we look further back (never forward) by a random offset,
+ * so different runs sample different time cohorts.
+ */
+function applyJitter(since: number, jitterSeconds: number): number {
+  const offset = Math.floor(Math.random() * jitterSeconds);
+  return since - offset;
+}
+
+export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
+  // Check nak availability
+  const nakPath = await checkNak();
+  if (!nakPath) {
+    console.error('Error: nak is not installed.');
+    console.error('Install from: https://github.com/fiatjaf/nak');
+    process.exit(1);
+  }
+  console.log(`Using nak: ${nakPath}`);
+
+  // Parse kinds
+  const kinds = opts.kinds
+    ? opts.kinds.split(',').map(k => parseInt(k.trim(), 10)).filter(k => !isNaN(k))
+    : DEFAULT_KINDS;
+
+  // Parse relays
+  const relays = opts.relays
+    ? opts.relays.split(',').map(r => r.trim())
+    : DEFAULT_RELAYS;
+
+  // Determine since timestamp
+  let since: number;
+  if (opts.since) {
+    const duration = parseDuration(opts.since);
+    since = Math.floor(Date.now() / 1000) - duration;
+  } else {
+    const hwm = getHighWaterMark();
+    since = hwm ?? Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
+  }
+
+  // Apply time jitter: randomly look further back by up to 6 hours
+  // so consecutive runs sample different time cohorts
+  const jitterSeconds = opts.jitter ? parseDuration(opts.jitter) : 6 * 3600;
+  const originalSince = since;
+  since = applyJitter(since, jitterSeconds);
+  const jitterApplied = originalSince - since;
+
+  // Check schema availability
+  const { available, missing } = checkSchemaAvailability(kinds);
+  console.log(`\nSchema coverage: ${available.length}/${kinds.length} kinds`);
+  if (missing.length > 0) {
+    console.log(`  Missing schemas: ${missing.join(', ')}`);
+    console.log(`  Events for these kinds will be stored with valid=NULL`);
+  }
+
+  const sinceDate = new Date(since * 1000).toISOString();
+  const numBatches = Math.ceil(kinds.length / DEFAULT_KIND_BATCH_SIZE);
+  console.log(`\nScanning ${kinds.length} kinds in ${numBatches} batches from ${relays.length} relays`);
+  console.log(`  Kinds: ${kinds.join(', ')}`);
+  console.log(`  Relays: ${relays.join(', ')} (order randomized)`);
+  console.log(`  Since: ${sinceDate} (jitter: -${Math.floor(jitterApplied / 60)}m)`);
+  console.log('');
+
+  const progress: ScanProgress = {
+    fetched: 0,
+    duplicates: 0,
+    validated: 0,
+    violations: 0,
+    rateLimits: 0,
+  };
+  const rateLimitEvents: RateLimitEvent[] = [];
+
+  // Ensure DB is initialized
+  getDb();
+
+  const startTime = Date.now();
+
+  await fetchEvents({
+    kinds,
+    relays,
+    since,
+    onRelayStart: (relay, index, total) => {
+      console.log(`  [relay ${index + 1}/${total}] ${relay}`);
+    },
+    onRelayDone: (relay, count) => {
+      console.log(`  [done] ${relay}: ${formatNumber(count)} events\n`);
+    },
+    onBatchStart: (_relay, batchKinds, batchIndex, totalBatches) => {
+      console.log(`    batch ${batchIndex + 1}/${totalBatches}: kinds [${batchKinds.join(', ')}]`);
+    },
+    onRateLimit: (event) => {
+      progress.rateLimits++;
+      rateLimitEvents.push(event);
+      console.error(`    !! RATE LIMITED by ${event.relay}: ${event.reason}`);
+    },
+    onEvent: (event) => {
+      progress.fetched++;
+
+      const validation = validateEvent(event);
+      const client = extractClientTag(event.tags);
+      const isNew = storeEvent(event, validation, client);
+
+      if (!isNew) {
+        progress.duplicates++;
+      } else {
+        progress.validated++;
+        if (validation.valid === false) {
+          progress.violations += validation.errors.length;
+        }
+      }
+
+      if (progress.fetched % 500 === 0) {
+        process.stdout.write(`\r    ${formatNumber(progress.fetched)} events processed...`);
+      }
+    },
+    onError: (error) => {
+      console.error(`\n  Warning: ${error}`);
+    },
+  });
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log('');
+  console.log(`Finished in ${elapsed}s`);
+  console.log('');
+  console.log('Results:');
+  console.log(`  Total fetched:  ${formatNumber(progress.fetched)}`);
+  console.log(`  New events:     ${formatNumber(progress.validated)}`);
+  console.log(`  Duplicates:     ${formatNumber(progress.duplicates)}`);
+  console.log(`  Violations:     ${formatNumber(progress.violations)}`);
+
+  if (progress.rateLimits > 0) {
+    console.log('');
+    console.log(`  !! Rate limited ${progress.rateLimits} time(s):`);
+    for (const rl of rateLimitEvents) {
+      console.log(`     ${rl.relay}: ${rl.reason}`);
+    }
+    console.log('');
+    console.log('  Consider: fewer kinds per batch, longer paginate interval, or fewer relays.');
+  }
+}

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,0 +1,50 @@
+import {
+  getTotalEvents,
+  getEventCountsByKind,
+  getHighWaterMark,
+  getDb,
+} from '../db/index.js';
+import { formatNumber, formatPercent } from '../util.js';
+
+export function statsCommand(): void {
+  getDb(); // ensure initialized
+
+  const total = getTotalEvents();
+  if (total === 0) {
+    console.log('No events in database. Run `sherlock scan` first.');
+    return;
+  }
+
+  const byKind = getEventCountsByKind();
+  const hwm = getHighWaterMark();
+
+  let totalValid = 0;
+  let totalInvalid = 0;
+  let totalNoSchema = 0;
+  for (const row of byKind) {
+    totalValid += row.valid;
+    totalInvalid += row.invalid;
+    totalNoSchema += row.no_schema;
+  }
+
+  console.log('\nSherlock Stats\n');
+  console.log(`  Total events:     ${formatNumber(total)}`);
+  console.log(`  Valid:            ${formatNumber(totalValid)} (${formatPercent(totalValid, total)})`);
+  console.log(`  Invalid:          ${formatNumber(totalInvalid)} (${formatPercent(totalInvalid, total)})`);
+  console.log(`  No schema:        ${formatNumber(totalNoSchema)} (${formatPercent(totalNoSchema, total)})`);
+
+  if (hwm) {
+    console.log(`  Last event:       ${new Date(hwm * 1000).toISOString()}`);
+  }
+
+  console.log('\nBy Kind:\n');
+  console.log(`${'Kind'.padEnd(10)} ${'Total'.padStart(8)} ${'Valid'.padStart(8)} ${'Invalid'.padStart(8)} ${'No Schema'.padStart(10)} ${'Error Rate'.padStart(12)}`);
+  console.log('-'.repeat(60));
+  for (const row of byKind) {
+    const validated = row.valid + row.invalid;
+    const errorRate = validated > 0 ? formatPercent(row.invalid, validated) : 'N/A';
+    console.log(
+      `${String(row.kind).padEnd(10)} ${String(row.total).padStart(8)} ${String(row.valid).padStart(8)} ${String(row.invalid).padStart(8)} ${String(row.no_schema).padStart(10)} ${errorRate.padStart(12)}`
+    );
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,61 @@
+export const DEFAULT_RELAYS = [
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+  'wss://relay.nostr.band',
+];
+
+export const DEFAULT_KINDS = [
+  0,      // NIP-01: Profile metadata
+  3,      // NIP-02: Contact list
+  10002,  // NIP-65: Relay list metadata
+  30023,  // NIP-23: Long-form content
+  14,     // NIP-17: Direct message
+  15,     // NIP-17: File message
+  10050,  // NIP-17: DM relay list
+  13,     // NIP-59: Seal
+  1059,   // NIP-59: Gift wrap
+  13194,  // NIP-47: NWC info
+  23194,  // NIP-47: NWC request
+  23195,  // NIP-47: NWC response
+  23196,  // NIP-47: NWC notification request
+  23197,  // NIP-47: NWC notification
+  9734,   // NIP-57: Zap request
+  9735,   // NIP-57: Zap receipt
+];
+
+// Default scan window: 24 hours
+export const DEFAULT_SCAN_WINDOW_SECONDS = 24 * 60 * 60;
+
+// Relay-friendly spacing
+export const DEFAULT_PAGINATE_INTERVAL = '5s';   // pause between paginated pages
+export const DEFAULT_RELAY_PAUSE_MS = 3000;       // pause between sequential relay scans
+export const DEFAULT_BATCH_PAUSE_MS = 2000;       // pause between kind batches on same relay
+export const DEFAULT_KIND_BATCH_SIZE = 5;         // max kinds per REQ filter
+
+export const DB_FILENAME = 'sherlock.db';
+
+export const GITHUB_REPO = 'https://github.com/nostrability/sherlock';
+
+export const KIND_NAMES: Record<number, string> = {
+  0:     'Profile Metadata (NIP-01)',
+  3:     'Contact List (NIP-02)',
+  10002: 'Relay List Metadata (NIP-65)',
+  30023: 'Long-form Content (NIP-23)',
+  14:    'Direct Message (NIP-17)',
+  15:    'File Message (NIP-17)',
+  10050: 'DM Relay List (NIP-17)',
+  13:    'Seal (NIP-59)',
+  1059:  'Gift Wrap (NIP-59)',
+  13194: 'NWC Info (NIP-47)',
+  23194: 'NWC Request (NIP-47)',
+  23195: 'NWC Response (NIP-47)',
+  23196: 'NWC Notification Request (NIP-47)',
+  23197: 'NWC Notification (NIP-47)',
+  9734:  'Zap Request (NIP-57)',
+  9735:  'Zap Receipt (NIP-57)',
+};
+
+export const STATUS_THRESHOLDS = {
+  MIN_EVENTS: 5,
+  ALMOST_MAX: 0.05,  // ≤5% error rate = "almost clean"
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ export const DEFAULT_RELAYS = [
   'wss://relay.nostr.band',
 ];
 
+export const PUBLISH_RELAYS = DEFAULT_RELAYS;
+
 export const DEFAULT_KINDS = [
   0,      // NIP-01: Profile metadata
   3,      // NIP-02: Contact list

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -250,15 +250,15 @@ export function getViolationDetails(): Array<{
 }
 
 export function getTopPubkeysForErrors(): Array<{
-  error_keyword: string | null; error_path: string | null; pubkey: string; cnt: number;
+  error_keyword: string | null; error_path: string | null; error_message: string; pubkey: string; cnt: number;
 }> {
   return getDb().prepare(`
-    SELECT v.error_keyword, v.error_path, e.pubkey, COUNT(*) as cnt
+    SELECT v.error_keyword, v.error_path, v.error_message, e.pubkey, COUNT(*) as cnt
     FROM violations v JOIN events e ON e.id = v.event_id
-    GROUP BY 1, 2, 3
-    ORDER BY 1, 2, cnt DESC
+    GROUP BY 1, 2, 3, 4
+    ORDER BY 1, 2, 3, cnt DESC
   `).all() as Array<{
-    error_keyword: string | null; error_path: string | null; pubkey: string; cnt: number;
+    error_keyword: string | null; error_path: string | null; error_message: string; pubkey: string; cnt: number;
   }>;
 }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -231,6 +231,7 @@ export function getViolationDetails(): Array<{
           AND e2.kind = base.kind
           AND v2.error_keyword IS base.error_keyword
           AND v2.error_path IS base.error_path
+          AND v2.error_message = base.error_message
         LIMIT 3
       )
     ) as sample_event_ids

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,268 @@
+import Database from 'better-sqlite3';
+import { resolve } from 'node:path';
+import { DB_FILENAME } from '../config.js';
+import type { NostrEvent, ValidationResult, ClientAttribution } from '../types.js';
+
+const SCHEMA_DDL = `
+CREATE TABLE IF NOT EXISTS events (
+  id            TEXT PRIMARY KEY,
+  pubkey        TEXT NOT NULL,
+  kind          INTEGER NOT NULL,
+  created_at    INTEGER NOT NULL,
+  tags          TEXT,
+  raw           TEXT NOT NULL,
+  client_name   TEXT,
+  source_relay  TEXT,
+  scanned_at    INTEGER NOT NULL DEFAULT (unixepoch()),
+  valid         INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS violations (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id      TEXT NOT NULL REFERENCES events(id),
+  schema_key    TEXT NOT NULL,
+  error_path    TEXT,
+  error_message TEXT NOT NULL,
+  error_keyword TEXT,
+  severity      TEXT NOT NULL DEFAULT 'error'
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_kind ON events(kind);
+CREATE INDEX IF NOT EXISTS idx_events_valid ON events(valid);
+CREATE INDEX IF NOT EXISTS idx_events_client ON events(client_name);
+CREATE INDEX IF NOT EXISTS idx_violations_event ON violations(event_id);
+`;
+
+let db: Database.Database | null = null;
+
+export function getDb(): Database.Database {
+  if (db) return db;
+  const dbPath = resolve(process.cwd(), DB_FILENAME);
+  db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(SCHEMA_DDL);
+  return db;
+}
+
+export function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+const insertEventStmt = () => getDb().prepare(`
+  INSERT OR IGNORE INTO events (id, pubkey, kind, created_at, tags, raw, client_name, source_relay, valid)
+  VALUES (@id, @pubkey, @kind, @created_at, @tags, @raw, @client_name, @source_relay, @valid)
+`);
+
+const insertViolationStmt = () => getDb().prepare(`
+  INSERT INTO violations (event_id, schema_key, error_path, error_message, error_keyword, severity)
+  VALUES (@event_id, @schema_key, @error_path, @error_message, @error_keyword, @severity)
+`);
+
+let _insertEvent: Database.Statement | null = null;
+let _insertViolation: Database.Statement | null = null;
+
+function getInsertEvent() {
+  if (!_insertEvent) _insertEvent = insertEventStmt();
+  return _insertEvent;
+}
+
+function getInsertViolation() {
+  if (!_insertViolation) _insertViolation = insertViolationStmt();
+  return _insertViolation;
+}
+
+/**
+ * Insert an event and its violations in a single transaction.
+ * Returns true if the event was new (inserted), false if duplicate.
+ */
+export function storeEvent(
+  event: NostrEvent,
+  validation: ValidationResult,
+  client: ClientAttribution | null,
+): boolean {
+  const raw = JSON.stringify(event);
+  const validValue = validation.valid === null ? null : validation.valid ? 1 : 0;
+
+  const result = getInsertEvent().run({
+    id: event.id,
+    pubkey: event.pubkey,
+    kind: event.kind,
+    created_at: event.created_at,
+    tags: JSON.stringify(event.tags),
+    raw,
+    client_name: client?.name ?? null,
+    source_relay: null,
+    valid: validValue,
+  });
+
+  if (result.changes === 0) return false; // duplicate
+
+  if (validation.errors.length > 0 && validation.schemaKey) {
+    const stmt = getInsertViolation();
+    for (const err of validation.errors) {
+      stmt.run({
+        event_id: event.id,
+        schema_key: validation.schemaKey,
+        error_path: err.instancePath || null,
+        error_message: err.message || 'unknown error',
+        error_keyword: err.keyword || null,
+        severity: 'error',
+      });
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Get the most recent created_at for a given kind, used for --since on next scan.
+ */
+export function getHighWaterMark(kind?: number): number | null {
+  const query = kind !== undefined
+    ? getDb().prepare('SELECT MAX(created_at) as max_ts FROM events WHERE kind = ?').get(kind) as { max_ts: number | null } | undefined
+    : getDb().prepare('SELECT MAX(created_at) as max_ts FROM events').get() as { max_ts: number | null } | undefined;
+  return query?.max_ts ?? null;
+}
+
+export function getTotalEvents(): number {
+  const row = getDb().prepare('SELECT COUNT(*) as cnt FROM events').get() as { cnt: number };
+  return row.cnt;
+}
+
+export function getEventCountsByKind(): Array<{ kind: number; total: number; valid: number; invalid: number; no_schema: number }> {
+  const rows = getDb().prepare(`
+    SELECT kind,
+      COUNT(*) as total,
+      SUM(CASE WHEN valid = 1 THEN 1 ELSE 0 END) as valid,
+      SUM(CASE WHEN valid = 0 THEN 1 ELSE 0 END) as invalid,
+      SUM(CASE WHEN valid IS NULL THEN 1 ELSE 0 END) as no_schema
+    FROM events
+    GROUP BY kind
+    ORDER BY kind
+  `).all() as Array<{ kind: number; total: number; valid: number; invalid: number; no_schema: number }>;
+  return rows;
+}
+
+export function getViolationsByKind(): Array<{ kind: number; schema_key: string; error_keyword: string | null; error_count: number }> {
+  const rows = getDb().prepare(`
+    SELECT e.kind, v.schema_key, v.error_keyword, COUNT(*) as error_count
+    FROM violations v
+    JOIN events e ON e.id = v.event_id
+    GROUP BY e.kind, v.schema_key, v.error_keyword
+    ORDER BY error_count DESC
+  `).all() as Array<{ kind: number; schema_key: string; error_keyword: string | null; error_count: number }>;
+  return rows;
+}
+
+export function getViolationsByClient(): Array<{ client_name: string | null; total_events: number; invalid_events: number; violation_count: number }> {
+  const rows = getDb().prepare(`
+    SELECT
+      e.client_name,
+      COUNT(DISTINCT e.id) as total_events,
+      COUNT(DISTINCT CASE WHEN e.valid = 0 THEN e.id END) as invalid_events,
+      COUNT(v.id) as violation_count
+    FROM events e
+    LEFT JOIN violations v ON v.event_id = e.id
+    WHERE e.client_name IS NOT NULL
+    GROUP BY e.client_name
+    ORDER BY violation_count DESC
+  `).all() as Array<{ client_name: string | null; total_events: number; invalid_events: number; violation_count: number }>;
+  return rows;
+}
+
+export function getViolationsByError(): Array<{ error_keyword: string | null; error_path: string | null; error_message: string; count: number }> {
+  const rows = getDb().prepare(`
+    SELECT error_keyword, error_path, error_message, COUNT(*) as count
+    FROM violations
+    GROUP BY error_keyword, error_path, error_message
+    ORDER BY count DESC
+    LIMIT 50
+  `).all() as Array<{ error_keyword: string | null; error_path: string | null; error_message: string; count: number }>;
+  return rows;
+}
+
+export function getRecentViolations(limit: number = 20): Array<{ event_id: string; kind: number; client_name: string | null; error_path: string | null; error_message: string; error_keyword: string | null }> {
+  const rows = getDb().prepare(`
+    SELECT v.event_id, e.kind, e.client_name, v.error_path, v.error_message, v.error_keyword
+    FROM violations v
+    JOIN events e ON e.id = v.event_id
+    ORDER BY e.created_at DESC
+    LIMIT ?
+  `).all(limit) as Array<{ event_id: string; kind: number; client_name: string | null; error_path: string | null; error_message: string; error_keyword: string | null }>;
+  return rows;
+}
+
+// --- Export queries ---
+
+export function getAppKindMatrix(): Array<{ client_name: string; kind: number; total: number; valid: number; invalid: number }> {
+  return getDb().prepare(`
+    SELECT COALESCE(client_name, '_unattributed') as client_name, kind,
+      COUNT(*) as total,
+      SUM(CASE WHEN valid = 1 THEN 1 ELSE 0 END) as valid,
+      SUM(CASE WHEN valid = 0 THEN 1 ELSE 0 END) as invalid
+    FROM events
+    GROUP BY 1, 2
+    ORDER BY total DESC
+  `).all() as Array<{ client_name: string; kind: number; total: number; valid: number; invalid: number }>;
+}
+
+export function getViolationDetails(): Array<{
+  client_name: string; kind: number; error_keyword: string | null;
+  error_path: string | null; error_message: string; count: number;
+  sample_event_ids: string | null;
+}> {
+  return getDb().prepare(`
+    SELECT base.*, (
+      SELECT GROUP_CONCAT(sub_id) FROM (
+        SELECT e2.id as sub_id FROM violations v2
+        JOIN events e2 ON e2.id = v2.event_id
+        WHERE COALESCE(e2.client_name, '_unattributed') = base.client_name
+          AND e2.kind = base.kind
+          AND v2.error_keyword IS base.error_keyword
+          AND v2.error_path IS base.error_path
+        LIMIT 3
+      )
+    ) as sample_event_ids
+    FROM (
+      SELECT COALESCE(e.client_name, '_unattributed') as client_name, e.kind,
+        v.error_keyword, v.error_path, v.error_message, COUNT(*) as count
+      FROM violations v JOIN events e ON e.id = v.event_id
+      GROUP BY 1, 2, 3, 4, 5
+    ) base
+    ORDER BY count DESC
+  `).all() as Array<{
+    client_name: string; kind: number; error_keyword: string | null;
+    error_path: string | null; error_message: string; count: number;
+    sample_event_ids: string | null;
+  }>;
+}
+
+export function getTopPubkeysForErrors(): Array<{
+  error_keyword: string | null; error_path: string | null; pubkey: string; cnt: number;
+}> {
+  return getDb().prepare(`
+    SELECT v.error_keyword, v.error_path, e.pubkey, COUNT(*) as cnt
+    FROM violations v JOIN events e ON e.id = v.event_id
+    GROUP BY 1, 2, 3
+    ORDER BY 1, 2, cnt DESC
+  `).all() as Array<{
+    error_keyword: string | null; error_path: string | null; pubkey: string; cnt: number;
+  }>;
+}
+
+export function getTimeRange(): { first_at: number | null; last_at: number | null } {
+  return getDb().prepare(
+    'SELECT MIN(created_at) as first_at, MAX(created_at) as last_at FROM events'
+  ).get() as { first_at: number | null; last_at: number | null };
+}
+
+export function getDistinctRelays(): string[] {
+  const rows = getDb().prepare(
+    'SELECT DISTINCT source_relay FROM events WHERE source_relay IS NOT NULL ORDER BY source_relay'
+  ).all() as Array<{ source_relay: string }>;
+  return rows.map(r => r.source_relay);
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -232,6 +232,7 @@ export function getViolationDetails(): Array<{
           AND v2.error_keyword IS base.error_keyword
           AND v2.error_path IS base.error_path
           AND v2.error_message = base.error_message
+        ORDER BY e2.created_at DESC, e2.id
         LIMIT 3
       )
     ) as sample_event_ids

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -47,6 +47,8 @@ export function getDb(): Database.Database {
 
 export function closeDb(): void {
   if (db) {
+    _insertEvent = null;
+    _insertViolation = null;
     db.close();
     db = null;
   }
@@ -83,39 +85,44 @@ export function storeEvent(
   event: NostrEvent,
   validation: ValidationResult,
   client: ClientAttribution | null,
+  sourceRelay?: string,
 ): boolean {
   const raw = JSON.stringify(event);
   const validValue = validation.valid === null ? null : validation.valid ? 1 : 0;
 
-  const result = getInsertEvent().run({
-    id: event.id,
-    pubkey: event.pubkey,
-    kind: event.kind,
-    created_at: event.created_at,
-    tags: JSON.stringify(event.tags),
-    raw,
-    client_name: client?.name ?? null,
-    source_relay: null,
-    valid: validValue,
+  const txn = getDb().transaction(() => {
+    const result = getInsertEvent().run({
+      id: event.id,
+      pubkey: event.pubkey,
+      kind: event.kind,
+      created_at: event.created_at,
+      tags: JSON.stringify(event.tags),
+      raw,
+      client_name: client?.name ?? null,
+      source_relay: sourceRelay ?? null,
+      valid: validValue,
+    });
+
+    if (result.changes === 0) return false; // duplicate
+
+    if (validation.errors.length > 0 && validation.schemaKey) {
+      const stmt = getInsertViolation();
+      for (const err of validation.errors) {
+        stmt.run({
+          event_id: event.id,
+          schema_key: validation.schemaKey,
+          error_path: err.instancePath || null,
+          error_message: err.message || 'unknown error',
+          error_keyword: err.keyword || null,
+          severity: 'error',
+        });
+      }
+    }
+
+    return true;
   });
 
-  if (result.changes === 0) return false; // duplicate
-
-  if (validation.errors.length > 0 && validation.schemaKey) {
-    const stmt = getInsertViolation();
-    for (const err of validation.errors) {
-      stmt.run({
-        event_id: event.id,
-        schema_key: validation.schemaKey,
-        error_path: err.instancePath || null,
-        error_message: err.message || 'unknown error',
-        error_keyword: err.keyword || null,
-        severity: 'error',
-      });
-    }
-  }
-
-  return true;
+  return txn();
 }
 
 /**

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -1,0 +1,213 @@
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { which } from '../util.js';
+import {
+  DEFAULT_PAGINATE_INTERVAL,
+  DEFAULT_RELAY_PAUSE_MS,
+  DEFAULT_BATCH_PAUSE_MS,
+  DEFAULT_KIND_BATCH_SIZE,
+} from '../config.js';
+import type { NostrEvent, RateLimitEvent } from '../types.js';
+
+// Patterns nak prints to stderr when a relay sends CLOSED
+const RATE_LIMIT_PATTERNS = [
+  'rate-limited',
+  'too many',
+  'slow down',
+  'throttl',
+];
+
+/**
+ * Check if nak is installed and accessible.
+ */
+export async function checkNak(): Promise<string | null> {
+  return which('nak');
+}
+
+export interface NakFetchOptions {
+  kinds: number[];
+  relays: string[];
+  since: number;
+  onEvent: (event: NostrEvent) => void;
+  onError?: (error: string) => void;
+  onRateLimit?: (event: RateLimitEvent) => void;
+  onRelayStart?: (relay: string, index: number, total: number) => void;
+  onRelayDone?: (relay: string, count: number) => void;
+  onBatchStart?: (relay: string, batchKinds: number[], batchIndex: number, totalBatches: number) => void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Fisher-Yates shuffle (in-place).
+ */
+export function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/**
+ * Check stderr output for rate limiting signals.
+ * nak prints "wss://relay.example.com CLOSED: rate-limited: ..." to stderr.
+ */
+function detectRateLimits(stderr: string, relay: string): RateLimitEvent[] {
+  const events: RateLimitEvent[] = [];
+  const lines = stderr.split('\n');
+  for (const line of lines) {
+    const lower = line.toLowerCase();
+    if (lower.includes('closed:') && RATE_LIMIT_PATTERNS.some(p => lower.includes(p))) {
+      events.push({ relay, reason: line.trim() });
+    }
+  }
+  return events;
+}
+
+/**
+ * Fetch events from a single relay for a batch of kinds via nak.
+ */
+async function fetchBatchFromRelay(
+  nakPath: string,
+  relay: string,
+  kinds: number[],
+  since: number,
+  onEvent: (event: NostrEvent) => void,
+  onError?: (error: string) => void,
+  onRateLimit?: (event: RateLimitEvent) => void,
+): Promise<number> {
+  const args = ['req'];
+
+  for (const kind of kinds) {
+    args.push('-k', String(kind));
+  }
+
+  args.push('--since', String(since));
+  args.push('--paginate');
+  args.push('--paginate-interval', DEFAULT_PAGINATE_INTERVAL);
+  args.push(relay);
+
+  return new Promise<number>((resolve, reject) => {
+    let count = 0;
+
+    const proc = spawn(nakPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const rl = createInterface({ input: proc.stdout });
+
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+
+      try {
+        const event = JSON.parse(trimmed) as NostrEvent;
+        if (event.id && event.kind !== undefined && event.pubkey) {
+          count++;
+          onEvent(event);
+        }
+      } catch {
+        onError?.(`Failed to parse nak output: ${trimmed.slice(0, 100)}`);
+      }
+    });
+
+    let stderr = '';
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', (code) => {
+      // Check for rate limiting in stderr regardless of exit code
+      const rateLimits = detectRateLimits(stderr, relay);
+      for (const rl of rateLimits) {
+        onRateLimit?.(rl);
+      }
+
+      if (code === 0) {
+        resolve(count);
+      } else if (code === 3) {
+        onError?.(`Relay ${relay} failed for kinds [${kinds}]: ${stderr.trim()}`);
+        resolve(count);
+      } else {
+        reject(new Error(`nak exited with code ${code} for ${relay}: ${stderr.trim()}`));
+      }
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to spawn nak: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Fetch events from all relays sequentially, batching kinds into small groups.
+ *
+ * Relays are shuffled to avoid always hitting the same relay first.
+ * Kind batches are also shuffled for sampling diversity.
+ */
+export async function fetchEvents(opts: NakFetchOptions): Promise<number> {
+  const nakPath = await checkNak();
+  if (!nakPath) {
+    throw new Error('nak is not installed. Install from: https://github.com/fiatjaf/nak');
+  }
+
+  // Shuffle relay order so we don't always hit the same one first
+  const relays = shuffle([...opts.relays]);
+
+  // Shuffle kind batches for sampling diversity
+  const kindBatches = shuffle(chunk([...opts.kinds], DEFAULT_KIND_BATCH_SIZE));
+
+  let totalCount = 0;
+
+  for (let ri = 0; ri < relays.length; ri++) {
+    const relay = relays[ri];
+
+    if (ri > 0) {
+      await sleep(DEFAULT_RELAY_PAUSE_MS);
+    }
+
+    opts.onRelayStart?.(relay, ri, relays.length);
+    let relayCount = 0;
+
+    for (let bi = 0; bi < kindBatches.length; bi++) {
+      const batch = kindBatches[bi];
+
+      if (bi > 0) {
+        await sleep(DEFAULT_BATCH_PAUSE_MS);
+      }
+
+      opts.onBatchStart?.(relay, batch, bi, kindBatches.length);
+
+      try {
+        const count = await fetchBatchFromRelay(
+          nakPath,
+          relay,
+          batch,
+          opts.since,
+          opts.onEvent,
+          opts.onError,
+          opts.onRateLimit,
+        );
+        relayCount += count;
+      } catch (err) {
+        opts.onError?.(`Error scanning ${relay} kinds [${batch}]: ${err}`);
+      }
+    }
+
+    totalCount += relayCount;
+    opts.onRelayDone?.(relay, relayCount);
+  }
+
+  return totalCount;
+}

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -28,6 +28,8 @@ export interface NakFetchOptions {
   kinds: number[];
   relays: string[];
   since: number;
+  /** Per-kind watermarks — if provided, each batch uses the minimum since across its kinds. */
+  perKindSince?: Map<number, number>;
   onEvent: (event: NostrEvent, relay: string) => void;
   onError?: (error: string) => void;
   onRateLimit?: (event: RateLimitEvent) => void;
@@ -189,12 +191,18 @@ export async function fetchEvents(opts: NakFetchOptions): Promise<number> {
 
       opts.onBatchStart?.(relay, batch, bi, kindBatches.length);
 
+      // Use per-kind watermarks if available: take the minimum since across this batch's kinds
+      let batchSince = opts.since;
+      if (opts.perKindSince) {
+        batchSince = Math.min(...batch.map(k => opts.perKindSince!.get(k) ?? opts.since));
+      }
+
       try {
         const count = await fetchBatchFromRelay(
           nakPath,
           relay,
           batch,
-          opts.since,
+          batchSince,
           opts.onEvent,
           opts.onError,
           opts.onRateLimit,

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -7,7 +7,24 @@ import {
   DEFAULT_BATCH_PAUSE_MS,
   DEFAULT_KIND_BATCH_SIZE,
 } from '../config.js';
+import type { ChildProcess } from 'node:child_process';
 import type { NostrEvent, RateLimitEvent } from '../types.js';
+
+// Track active child processes so we can kill them on SIGINT
+const activeProcs = new Set<ChildProcess>();
+let sigintHandlerInstalled = false;
+
+function installSigintHandler(): void {
+  if (sigintHandlerInstalled) return;
+  sigintHandlerInstalled = true;
+  process.on('SIGINT', () => {
+    for (const proc of activeProcs) {
+      proc.kill('SIGTERM');
+    }
+    activeProcs.clear();
+    process.exit(130); // standard SIGINT exit code
+  });
+}
 
 // Patterns nak prints to stderr when a relay sends CLOSED
 const RATE_LIMIT_PATTERNS = [
@@ -106,6 +123,7 @@ async function fetchBatchFromRelay(
     const proc = spawn(nakPath, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    activeProcs.add(proc);
 
     const rl = createInterface({ input: proc.stdout });
 
@@ -125,11 +143,16 @@ async function fetchBatchFromRelay(
     });
 
     let stderr = '';
+    const STDERR_MAX = 10240; // 10 KB cap
     proc.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString();
+      if (stderr.length < STDERR_MAX) {
+        stderr += chunk.toString();
+        if (stderr.length > STDERR_MAX) stderr = stderr.slice(0, STDERR_MAX);
+      }
     });
 
     proc.on('close', (code) => {
+      activeProcs.delete(proc);
       // Check for rate limiting in stderr regardless of exit code
       const rateLimits = detectRateLimits(stderr, relay);
       for (const rateLimit of rateLimits) {
@@ -163,6 +186,8 @@ export async function fetchEvents(opts: NakFetchOptions): Promise<number> {
   if (!nakPath) {
     throw new Error('nak is not installed. Install from: https://github.com/fiatjaf/nak');
   }
+
+  installSigintHandler();
 
   // Shuffle relay order so we don't always hit the same one first
   const relays = shuffle([...opts.relays]);

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -28,7 +28,7 @@ export interface NakFetchOptions {
   kinds: number[];
   relays: string[];
   since: number;
-  onEvent: (event: NostrEvent) => void;
+  onEvent: (event: NostrEvent, relay: string) => void;
   onError?: (error: string) => void;
   onRateLimit?: (event: RateLimitEvent) => void;
   onRelayStart?: (relay: string, index: number, total: number) => void;
@@ -83,7 +83,7 @@ async function fetchBatchFromRelay(
   relay: string,
   kinds: number[],
   since: number,
-  onEvent: (event: NostrEvent) => void,
+  onEvent: (event: NostrEvent, relay: string) => void,
   onError?: (error: string) => void,
   onRateLimit?: (event: RateLimitEvent) => void,
 ): Promise<number> {
@@ -115,7 +115,7 @@ async function fetchBatchFromRelay(
         const event = JSON.parse(trimmed) as NostrEvent;
         if (event.id && event.kind !== undefined && event.pubkey) {
           count++;
-          onEvent(event);
+          onEvent(event, relay);
         }
       } catch {
         onError?.(`Failed to parse nak output: ${trimmed.slice(0, 100)}`);
@@ -130,8 +130,8 @@ async function fetchBatchFromRelay(
     proc.on('close', (code) => {
       // Check for rate limiting in stderr regardless of exit code
       const rateLimits = detectRateLimits(stderr, relay);
-      for (const rl of rateLimits) {
-        onRateLimit?.(rl);
+      for (const rateLimit of rateLimits) {
+        onRateLimit?.(rateLimit);
       }
 
       if (code === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { scanCommand } from './commands/scan.js';
+import { reportCommand } from './commands/report.js';
+import { statsCommand } from './commands/stats.js';
+import { exportCommand } from './commands/export.js';
+import { closeDb } from './db/index.js';
+
+const program = new Command();
+
+program
+  .name('sherlock')
+  .description('Validate Nostr events against JSON Schemas and identify apps producing malformed blobs')
+  .version('0.1.0');
+
+program
+  .command('scan')
+  .description('Fetch and validate events from relays')
+  .option('--kinds <kinds>', 'Comma-separated list of kinds to scan (default: 0,3,10002,30023,14,15,10050,13,1059,13194,23194,23195,23196,23197,9734,9735)')
+  .option('--relays <relays>', 'Comma-separated list of relay URLs')
+  .option('--since <duration>', 'How far back to scan (e.g., 1h, 24h, 7d)')
+  .option('--jitter <duration>', 'Max random offset added to --since for cohort diversity (default: 6h)')
+  .action(async (opts) => {
+    try {
+      await scanCommand(opts);
+    } catch (err) {
+      console.error('Scan failed:', err);
+      process.exit(1);
+    } finally {
+      closeDb();
+    }
+  });
+
+program
+  .command('report')
+  .description('Show violation reports')
+  .option('--by <grouping>', 'Group by: kind, client, error, recent (default: kind)')
+  .option('--format <format>', 'Output format: table, json, csv (default: table)')
+  .option('--limit <n>', 'Limit number of results')
+  .action((opts) => {
+    try {
+      reportCommand(opts);
+    } finally {
+      closeDb();
+    }
+  });
+
+program
+  .command('stats')
+  .description('Show database statistics')
+  .action(() => {
+    try {
+      statsCommand();
+    } finally {
+      closeDb();
+    }
+  });
+
+program
+  .command('export')
+  .description('Export findings to JSON, HTML dashboard, and optionally publish to Nostr')
+  .option('--outdir <dir>', 'Output directory (default: current directory)')
+  .option('--publish', 'Publish report to Nostr via nak (requires NOSTR_SECRET_KEY)')
+  .action(async (opts) => {
+    try {
+      await exportCommand(opts);
+    } catch (err) {
+      console.error('Export failed:', err);
+      process.exit(1);
+    } finally {
+      closeDb();
+    }
+  });
+
+program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,9 @@ program
   .action((opts) => {
     try {
       reportCommand(opts);
+    } catch (err) {
+      console.error('Report failed:', err);
+      process.exit(1);
     } finally {
       closeDb();
     }
@@ -52,6 +55,9 @@ program
   .action(() => {
     try {
       statsCommand();
+    } catch (err) {
+      console.error('Stats failed:', err);
+      process.exit(1);
     } finally {
       closeDb();
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,64 @@
+import type { ErrorObject } from 'ajv';
+
+export interface NostrEvent {
+  id: string;
+  pubkey: string;
+  kind: number;
+  created_at: number;
+  content: string;
+  tags: string[][];
+  sig: string;
+}
+
+export interface ValidationResult {
+  valid: boolean | null;  // null = no schema for this kind
+  errors: ErrorObject[];
+  schemaKey: string | null;
+}
+
+export interface ClientAttribution {
+  name: string;
+  address?: string;
+}
+
+export interface ScanOptions {
+  kinds: number[];
+  relays: string[];
+  since: number;  // unix timestamp
+}
+
+export interface StoredEvent {
+  id: string;
+  pubkey: string;
+  kind: number;
+  created_at: number;
+  tags: string;       // JSON string
+  raw: string;        // full JSON
+  client_name: string | null;
+  source_relay: string | null;
+  scanned_at: number;
+  valid: number | null;  // 1=pass, 0=fail, null=no schema
+}
+
+export interface StoredViolation {
+  id: number;
+  event_id: string;
+  schema_key: string;
+  error_path: string | null;
+  error_message: string;
+  error_keyword: string | null;
+  severity: string;
+}
+
+export interface ScanProgress {
+  fetched: number;
+  duplicates: number;
+  validated: number;
+  violations: number;
+  rateLimits: number;
+}
+
+export interface RateLimitEvent {
+  relay: string;
+  reason: string;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process';
+
+/**
+ * Check if a command is available on PATH. Returns the path or null.
+ */
+export function which(cmd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile('which', [cmd], (err, stdout) => {
+      if (err) resolve(null);
+      else resolve(stdout.trim() || null);
+    });
+  });
+}
+
+/**
+ * Parse a human-friendly duration string to seconds.
+ * Supports: 1h, 24h, 7d, 30m, 1h30m, etc.
+ */
+export function parseDuration(input: string): number {
+  let total = 0;
+  const pattern = /(\d+)\s*(d|h|m|s)/gi;
+  let match;
+  while ((match = pattern.exec(input)) !== null) {
+    const value = parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    switch (unit) {
+      case 'd': total += value * 86400; break;
+      case 'h': total += value * 3600; break;
+      case 'm': total += value * 60; break;
+      case 's': total += value; break;
+    }
+  }
+  if (total === 0) {
+    // Try parsing as plain number (seconds)
+    const num = parseInt(input, 10);
+    if (!isNaN(num)) return num;
+    throw new Error(`Invalid duration: "${input}". Use formats like: 1h, 24h, 7d, 30m`);
+  }
+  return total;
+}
+
+/**
+ * Format a number with commas.
+ */
+export function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+/**
+ * Format a percentage with 1 decimal place.
+ */
+export function formatPercent(n: number, total: number): string {
+  if (total === 0) return '0.0%';
+  return (n / total * 100).toFixed(1) + '%';
+}

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -12,9 +12,9 @@ function loadSchemas(): Record<string, unknown> {
   // Walk the dist/nips directory to find kind schemas directly
   // (the ESM bundle re-exports don't work with require())
   const schemataDir = require.resolve('@nostrability/schemata/package.json');
-  const pkgDir = schemataDir.replace('/package.json', '');
-  const fs = require('fs');
   const path = require('path');
+  const pkgDir = path.dirname(schemataDir);
+  const fs = require('fs');
 
   schemas = {};
   const nipsDir = path.join(pkgDir, 'dist', 'nips');
@@ -117,15 +117,19 @@ function stripErrorMessages(obj: unknown): void {
 
 /**
  * Check that schemata package is importable and has schemas for our target kinds.
+ * Also verifies schemas can be compiled by AJV (triggers lazy compilation + caching).
  * Returns list of available kind schema keys.
  */
 export function checkSchemaAvailability(kinds: number[]): { available: string[]; missing: string[] } {
-  const allSchemas = loadSchemas();
   const available: string[] = [];
   const missing: string[] = [];
   for (const kind of kinds) {
     const key = `kind${kind}Schema`;
-    if (allSchemas[key]) {
+    // Trigger validateEvent to force schema compilation and caching.
+    // A dummy event is used — we only care whether a validator was produced.
+    const dummyEvent: NostrEvent = { id: '', pubkey: '', kind, created_at: 0, tags: [], content: '', sig: '' };
+    const result = validateEvent(dummyEvent);
+    if (result.schemaKey) {
       available.push(key);
     } else {
       missing.push(key);

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -36,7 +36,11 @@ function loadSchemas(): Record<string, unknown> {
         const schemaPath = path.join(nipPath, entry, 'schema.json');
         if (fs.existsSync(schemaPath)) {
           const key = `kind${kindNum}Schema`;
-          schemas[key] = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+          try {
+            schemas[key] = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+          } catch (err) {
+            console.error(`Warning: Failed to parse ${schemaPath}:`, err);
+          }
         }
       }
     }

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -1,0 +1,136 @@
+import { createRequire } from 'node:module';
+import Ajv, { type ValidateFunction } from 'ajv';
+import type { NostrEvent, ValidationResult } from '../types.js';
+
+const require = createRequire(import.meta.url);
+
+// Load all schemas from the schemata package via require (avoids Node 22+ ESM JSON import issue)
+let schemas: Record<string, unknown> | null = null;
+
+function loadSchemas(): Record<string, unknown> {
+  if (schemas) return schemas;
+  // The bundle's schemas.js re-exports from .json files; require() handles JSON natively
+  const bundlePath = require.resolve('@nostrability/schemata');
+  // bundlePath points to dist/bundle/schemas.js — but that's ESM with re-exports.
+  // Instead, walk the dist/nips directory to find kind schemas directly.
+  const schemataDir = require.resolve('@nostrability/schemata/package.json');
+  const pkgDir = schemataDir.replace('/package.json', '');
+  const fs = require('fs');
+  const path = require('path');
+
+  schemas = {};
+  const nipsDir = path.join(pkgDir, 'dist', 'nips');
+  if (!fs.existsSync(nipsDir)) {
+    console.error(`Warning: schemata nips directory not found at ${nipsDir}`);
+    return schemas;
+  }
+
+  // Walk nips directory for kind-N/schema.json files
+  const nipDirs = fs.readdirSync(nipsDir);
+  for (const nipDir of nipDirs) {
+    const nipPath = path.join(nipsDir, nipDir);
+    const entries = fs.readdirSync(nipPath);
+    for (const entry of entries) {
+      const match = entry.match(/^kind-(\d+)$/);
+      if (match) {
+        const kindNum = match[1];
+        const schemaPath = path.join(nipPath, entry, 'schema.json');
+        if (fs.existsSync(schemaPath)) {
+          const key = `kind${kindNum}Schema`;
+          schemas[key] = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+        }
+      }
+    }
+  }
+
+  return schemas;
+}
+
+const ajv = new Ajv({ strict: false, allErrors: true });
+const cache = new Map<string, ValidateFunction | null>();
+
+/**
+ * Recursively remove $schema and $id from nested objects to prevent AJV conflicts.
+ * Keeps root-level $schema intact (AJV uses it for draft detection).
+ */
+function stripNestedMetaFields(obj: unknown, isRoot = true): void {
+  if (typeof obj !== 'object' || obj === null) return;
+  if (Array.isArray(obj)) {
+    for (const item of obj) stripNestedMetaFields(item, false);
+    return;
+  }
+  const record = obj as Record<string, unknown>;
+  if (!isRoot) {
+    delete record['$schema'];
+    delete record['$id'];
+  }
+  for (const value of Object.values(record)) {
+    stripNestedMetaFields(value, false);
+  }
+}
+
+export function validateEvent(event: NostrEvent): ValidationResult {
+  const key = `kind${event.kind}Schema`;
+  if (!cache.has(key)) {
+    const allSchemas = loadSchemas();
+    const schema = allSchemas[key];
+    if (!schema) {
+      cache.set(key, null);
+    } else {
+      try {
+        const cloned = structuredClone(schema);
+        stripNestedMetaFields(cloned);
+        // Remove errorMessage fields (requires ajv-errors plugin we don't use)
+        stripErrorMessages(cloned);
+        cache.set(key, ajv.compile(cloned as object));
+      } catch (err) {
+        console.error(`Warning: Failed to compile schema ${key}:`, err);
+        cache.set(key, null);
+      }
+    }
+  }
+
+  const validate = cache.get(key);
+  if (!validate) {
+    return { valid: null, errors: [], schemaKey: null };
+  }
+
+  const valid = validate(event);
+  return {
+    valid: !!valid,
+    errors: validate.errors ? [...validate.errors] : [],
+    schemaKey: key,
+  };
+}
+
+function stripErrorMessages(obj: unknown): void {
+  if (typeof obj !== 'object' || obj === null) return;
+  if (Array.isArray(obj)) {
+    for (const item of obj) stripErrorMessages(item);
+    return;
+  }
+  const record = obj as Record<string, unknown>;
+  delete record['errorMessage'];
+  for (const value of Object.values(record)) {
+    stripErrorMessages(value);
+  }
+}
+
+/**
+ * Check that schemata package is importable and has schemas for our target kinds.
+ * Returns list of available kind schema keys.
+ */
+export function checkSchemaAvailability(kinds: number[]): { available: string[]; missing: string[] } {
+  const allSchemas = loadSchemas();
+  const available: string[] = [];
+  const missing: string[] = [];
+  for (const kind of kinds) {
+    const key = `kind${kind}Schema`;
+    if (allSchemas[key]) {
+      available.push(key);
+    } else {
+      missing.push(key);
+    }
+  }
+  return { available, missing };
+}

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -9,10 +9,8 @@ let schemas: Record<string, unknown> | null = null;
 
 function loadSchemas(): Record<string, unknown> {
   if (schemas) return schemas;
-  // The bundle's schemas.js re-exports from .json files; require() handles JSON natively
-  const bundlePath = require.resolve('@nostrability/schemata');
-  // bundlePath points to dist/bundle/schemas.js — but that's ESM with re-exports.
-  // Instead, walk the dist/nips directory to find kind schemas directly.
+  // Walk the dist/nips directory to find kind schemas directly
+  // (the ESM bundle re-exports don't work with require())
   const schemataDir = require.resolve('@nostrability/schemata/package.json');
   const pkgDir = schemataDir.replace('/package.json', '');
   const fs = require('fs');
@@ -29,6 +27,7 @@ function loadSchemas(): Record<string, unknown> {
   const nipDirs = fs.readdirSync(nipsDir);
   for (const nipDir of nipDirs) {
     const nipPath = path.join(nipsDir, nipDir);
+    try { if (!fs.statSync(nipPath).isDirectory()) continue; } catch { continue; }
     const entries = fs.readdirSync(nipPath);
     for (const entry of entries) {
       const match = entry.match(/^kind-(\d+)$/);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Human Speak Overview

Basically not all devs have schemata in CI, or will have this in their CI. 

This means that there is a perpetual risk of broken/malformed events published to relays. 

Sherlock checks live events on relays, and catches these broken events by using the https://github.com/nostrability/schemata approach.

Sherlock then tries to deduce which apps are publishing broken stuff. 

## Summary

- **Scanner**: fetches events from relays via `nak`, validates against [schemata](https://github.com/nostrability/schemata) JSON Schemas using AJV, attributes to apps via NIP-89 client tags, stores results in SQLite. Covers 16 kinds across 8 NIPs.
- **Export command**: generates `data/findings.json` (machine-readable, three views: by kind, by app, error patterns) and `docs/index.html` (interactive dashboard with inlined data — no fetch, no CORS, works as a local file)
- **Nostr publishing**: daily kind:1 summary + kind:30023 full report published by the [nostrability bot](https://njump.me/npub1g5qtwz2nh9q0mnw555kv787kh6lysds95522gzptre3qpvz9p20s83m80d) via `nak`
- **CI workflow**: 3x/day scans at staggered UTC times, relay-friendly batching with jitter and rate-limit detection, cached SQLite DB between runs

### Dashboard
- Three tabs: **By Kind** | **By App** | **Errors**
- Expandable rows with per-app breakdowns, colored status dots (green/yellow/red)
- Top pubkeys per error pattern for app identification
- Dark mode via `prefers-color-scheme`, zero external dependencies

### Post-merge setup
1. Add `NOSTR_SECRET_KEY` (nsec/hex for the bot) to repo Settings → Secrets → Actions
2. Enable GitHub Pages: Settings → Pages → branch `main`, folder `/docs`
3. Trigger a manual workflow run to verify

## Test plan

- [ ] `npm install --legacy-peer-deps && npx tsc` — clean build
- [ ] `node dist/index.js scan --kinds 0,3 --since 30m --relays wss://relay.damus.io` — verify scanning
- [ ] `node dist/index.js export` — verify `data/findings.json` + `docs/index.html` generated
- [ ] Open `docs/index.html` in browser — verify all three tabs render
- [ ] `NOSTR_SECRET_KEY=<nsec> node dist/index.js export --publish` — verify notes published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sherlock CLI: scan, report, stats, and export commands for passive Nostr schema validation.
  * Exports findings as JSON and a self-contained HTML dashboard with views by kind, by app, and by error; export can optionally publish reports to Nostr.
  * Local SQLite persistence, configurable scanning controls (kinds/relays/since/jitter), and enhanced reporting (table/CSV/JSON).

* **Documentation**
  * Added README with usage, commands, outputs, setup, and schema coverage.

* **Chores**
  * Added scheduled CI workflow (three-times-daily) with manual inputs, caching, artifacts, and committing findings; added .gitignore and package manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->