### PR TITLE
feat: v2 attribution, trends, semantic validation, and drill-down

### DIFF
--- a/data/app-fingerprints.json
+++ b/data/app-fingerprints.json
@@ -1,0 +1,44 @@
+[
+  {
+    "app_name": "Damus",
+    "tag_pattern": [
+      { "tag": "client", "value": "damus" }
+    ]
+  },
+  {
+    "app_name": "Primal",
+    "content_pattern": [
+      "primal.net"
+    ]
+  },
+  {
+    "app_name": "Amethyst",
+    "tag_pattern": [
+      { "tag": "client", "value": "amethyst" }
+    ]
+  },
+  {
+    "app_name": "Snort",
+    "content_pattern": [
+      "snort.social"
+    ]
+  },
+  {
+    "app_name": "Coracle",
+    "content_pattern": [
+      "coracle.social"
+    ]
+  },
+  {
+    "app_name": "Nostrudel",
+    "content_pattern": [
+      "nostrudel.ninja"
+    ]
+  },
+  {
+    "app_name": "Gossip",
+    "tag_pattern": [
+      { "tag": "client", "value": "gossip" }
+    ]
+  }
+]

--- a/src/attribution/fingerprints.ts
+++ b/src/attribution/fingerprints.ts
@@ -20,9 +20,15 @@ export function loadFingerprints(): AppFingerprint[] {
   try {
     const raw = readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(raw) as unknown[];
-    cached = parsed.filter((entry): entry is AppFingerprint =>
-      typeof entry === 'object' && entry !== null && 'app_name' in entry
-    );
+    cached = parsed.filter((entry): entry is AppFingerprint => {
+      if (typeof entry !== 'object' || entry === null) return false;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.app_name !== 'string') return false;
+      if (e.pubkey_prefix !== undefined && !(Array.isArray(e.pubkey_prefix) && e.pubkey_prefix.every(v => typeof v === 'string'))) return false;
+      if (e.tag_pattern !== undefined && !Array.isArray(e.tag_pattern)) return false;
+      if (e.content_pattern !== undefined && !(Array.isArray(e.content_pattern) && e.content_pattern.every(v => typeof v === 'string'))) return false;
+      return true;
+    });
     return cached;
   } catch (err) {
     console.error(`Warning: Failed to load fingerprints from ${filePath}: ${err}`);

--- a/src/attribution/fingerprints.ts
+++ b/src/attribution/fingerprints.ts
@@ -1,0 +1,29 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { AppFingerprint } from '../types.js';
+
+let cached: AppFingerprint[] | null = null;
+
+/**
+ * Load app fingerprint patterns from data/app-fingerprints.json.
+ * Returns empty array if file doesn't exist (graceful degradation).
+ */
+export function loadFingerprints(): AppFingerprint[] {
+  if (cached) return cached;
+
+  const filePath = resolve(process.cwd(), 'data', 'app-fingerprints.json');
+  if (!existsSync(filePath)) {
+    cached = [];
+    return cached;
+  }
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    cached = JSON.parse(raw) as AppFingerprint[];
+    return cached;
+  } catch (err) {
+    console.error(`Warning: Failed to load fingerprints from ${filePath}: ${err}`);
+    cached = [];
+    return cached;
+  }
+}

--- a/src/attribution/fingerprints.ts
+++ b/src/attribution/fingerprints.ts
@@ -19,7 +19,10 @@ export function loadFingerprints(): AppFingerprint[] {
 
   try {
     const raw = readFileSync(filePath, 'utf-8');
-    cached = JSON.parse(raw) as AppFingerprint[];
+    const parsed = JSON.parse(raw) as unknown[];
+    cached = parsed.filter((entry): entry is AppFingerprint =>
+      typeof entry === 'object' && entry !== null && 'app_name' in entry
+    );
     return cached;
   } catch (err) {
     console.error(`Warning: Failed to load fingerprints from ${filePath}: ${err}`);

--- a/src/attribution/nip89.ts
+++ b/src/attribution/nip89.ts
@@ -14,11 +14,13 @@ function sleep(ms: number): Promise<void> {
  *
  * Follows relay-friendly conventions: sequential relay scanning with pauses.
  */
+type HandlerEntry = { name: string; address: string; created_at: number; id: string };
+
 export async function fetchNip89Handlers(relays: string[]): Promise<Map<string, { name: string; address: string }>> {
   const nakPath = await which('nak');
   if (!nakPath) return new Map();
 
-  const handlers = new Map<string, { name: string; address: string }>();
+  const handlers = new Map<string, HandlerEntry>();
 
   for (let i = 0; i < relays.length; i++) {
     const relay = relays[i];
@@ -35,7 +37,12 @@ export async function fetchNip89Handlers(relays: string[]): Promise<Map<string, 
     }
   }
 
-  return handlers;
+  // Strip internal fields before returning
+  const result = new Map<string, { name: string; address: string }>();
+  for (const [pubkey, entry] of handlers) {
+    result.set(pubkey, { name: entry.name, address: entry.address });
+  }
+  return result;
 }
 
 const NAK_TIMEOUT_MS = 60_000; // 60s max per relay
@@ -113,7 +120,7 @@ function fetchKind31990(nakPath: string, relay: string): Promise<NostrEvent[]> {
  */
 function processHandlerEvent(
   event: NostrEvent,
-  handlers: Map<string, { name: string; address: string }>,
+  handlers: Map<string, HandlerEntry>,
 ): void {
   try {
     // Try to parse content for app name
@@ -142,10 +149,12 @@ function processHandlerEvent(
     const dTag = event.tags.find(t => t[0] === 'd');
     const address = `31990:${event.pubkey}:${dTag?.[1] ?? ''}`;
 
-    // Map the handler's pubkey to the app
-    // Don't overwrite existing entries (first seen wins, usually most popular)
-    if (!handlers.has(event.pubkey)) {
-      handlers.set(event.pubkey, { name: appName, address });
+    // Map the handler's pubkey to the app — keep the newest event per pubkey
+    const existing = handlers.get(event.pubkey);
+    if (!existing) {
+      handlers.set(event.pubkey, { name: appName, address, created_at: event.created_at, id: event.id });
+    } else if (event.created_at > existing.created_at || (event.created_at === existing.created_at && event.id < existing.id)) {
+      handlers.set(event.pubkey, { name: appName, address, created_at: event.created_at, id: event.id });
     }
   } catch { /* skip malformed handler events */ }
 }

--- a/src/attribution/nip89.ts
+++ b/src/attribution/nip89.ts
@@ -38,14 +38,26 @@ export async function fetchNip89Handlers(relays: string[]): Promise<Map<string, 
   return handlers;
 }
 
+const NAK_TIMEOUT_MS = 60_000; // 60s max per relay
+const MAX_STDERR_LEN = 4096;
+
 function fetchKind31990(nakPath: string, relay: string): Promise<NostrEvent[]> {
   return new Promise((resolve, reject) => {
     const events: NostrEvent[] = [];
     const args = ['req', '-k', '31990', '--limit', '500', relay];
+    let settled = false;
 
     const proc = spawn(nakPath, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill();
+        resolve(events); // return whatever we got before timeout
+      }
+    }, NAK_TIMEOUT_MS);
 
     const rl = createInterface({ input: proc.stdout });
 
@@ -63,9 +75,15 @@ function fetchKind31990(nakPath: string, relay: string): Promise<NostrEvent[]> {
     let stderr = '';
     proc.stderr.on('data', (chunk: Buffer) => {
       stderr += chunk.toString();
+      if (stderr.length > MAX_STDERR_LEN) {
+        stderr = stderr.slice(-MAX_STDERR_LEN);
+      }
     });
 
     proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
       if (code === 0 || code === 3) {
         resolve(events);
       } else {
@@ -74,6 +92,9 @@ function fetchKind31990(nakPath: string, relay: string): Promise<NostrEvent[]> {
     });
 
     proc.on('error', (err) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
       reject(new Error(`Failed to spawn nak: ${err.message}`));
     });
   });

--- a/src/attribution/nip89.ts
+++ b/src/attribution/nip89.ts
@@ -1,0 +1,130 @@
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { which } from '../util.js';
+import { DEFAULT_RELAY_PAUSE_MS } from '../config.js';
+import type { NostrEvent } from '../types.js';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch kind:31990 (NIP-89 handler info) events from relays.
+ * Returns a Map<pubkey, {name, address}> for pubkey→app resolution.
+ *
+ * Follows relay-friendly conventions: sequential relay scanning with pauses.
+ */
+export async function fetchNip89Handlers(relays: string[]): Promise<Map<string, { name: string; address: string }>> {
+  const nakPath = await which('nak');
+  if (!nakPath) return new Map();
+
+  const handlers = new Map<string, { name: string; address: string }>();
+
+  for (let i = 0; i < relays.length; i++) {
+    const relay = relays[i];
+    if (i > 0) await sleep(DEFAULT_RELAY_PAUSE_MS);
+
+    try {
+      const events = await fetchKind31990(nakPath, relay);
+      for (const event of events) {
+        processHandlerEvent(event, handlers);
+      }
+    } catch (err) {
+      // Non-fatal: skip relay on error
+      console.error(`    Warning: NIP-89 fetch from ${relay} failed: ${err}`);
+    }
+  }
+
+  return handlers;
+}
+
+function fetchKind31990(nakPath: string, relay: string): Promise<NostrEvent[]> {
+  return new Promise((resolve, reject) => {
+    const events: NostrEvent[] = [];
+    const args = ['req', '-k', '31990', '--limit', '500', relay];
+
+    const proc = spawn(nakPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const rl = createInterface({ input: proc.stdout });
+
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      try {
+        const event = JSON.parse(trimmed) as NostrEvent;
+        if (event.id && event.kind === 31990) {
+          events.push(event);
+        }
+      } catch { /* skip malformed */ }
+    });
+
+    let stderr = '';
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0 || code === 3) {
+        resolve(events);
+      } else {
+        reject(new Error(`nak exited with code ${code}: ${stderr.trim()}`));
+      }
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to spawn nak: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Extract app name and pubkey bindings from a kind:31990 handler event.
+ *
+ * Handler events contain:
+ * - d tag: app identifier
+ * - content: JSON with name field
+ * - pubkey: the app operator's pubkey
+ *
+ * We map the handler's pubkey to the app name so events from that
+ * pubkey can be attributed to the app.
+ */
+function processHandlerEvent(
+  event: NostrEvent,
+  handlers: Map<string, { name: string; address: string }>,
+): void {
+  try {
+    // Try to parse content for app name
+    let appName: string | null = null;
+
+    if (event.content) {
+      try {
+        const content = JSON.parse(event.content);
+        if (content.name && typeof content.name === 'string') {
+          appName = content.name;
+        }
+      } catch { /* content may not be JSON */ }
+    }
+
+    // Fall back to d-tag value
+    if (!appName) {
+      const dTag = event.tags.find(t => t[0] === 'd');
+      if (dTag?.[1]) {
+        appName = dTag[1];
+      }
+    }
+
+    if (!appName) return;
+
+    // Build the NIP-89 address (31990:pubkey:d-tag)
+    const dTag = event.tags.find(t => t[0] === 'd');
+    const address = `31990:${event.pubkey}:${dTag?.[1] ?? ''}`;
+
+    // Map the handler's pubkey to the app
+    // Don't overwrite existing entries (first seen wins, usually most popular)
+    if (!handlers.has(event.pubkey)) {
+      handlers.set(event.pubkey, { name: appName, address });
+    }
+  } catch { /* skip malformed handler events */ }
+}

--- a/src/attribution/resolve.ts
+++ b/src/attribution/resolve.ts
@@ -1,0 +1,79 @@
+import { extractClientTag } from './client-tag.js';
+import type { NostrEvent, Attribution, AppFingerprint } from '../types.js';
+
+/**
+ * Unified attribution resolver with priority cascade:
+ * 1. Tier 1: NIP-89 client tag (high confidence)
+ * 2. Tier 2: NIP-89 pubkey→app map (medium confidence)
+ * 3. Tier 4: Fingerprint rules (low-medium confidence)
+ */
+export function resolveAttribution(
+  event: NostrEvent,
+  nip89Map: Map<string, { name: string; address: string }>,
+  fingerprints: AppFingerprint[],
+): Attribution | null {
+  // Tier 1: client tag
+  const clientTag = extractClientTag(event.tags);
+  if (clientTag) {
+    return {
+      name: clientTag.name,
+      method: 'client_tag',
+      confidence: 'high',
+      address: clientTag.address,
+    };
+  }
+
+  // Tier 2: NIP-89 pubkey lookup
+  const nip89Entry = nip89Map.get(event.pubkey);
+  if (nip89Entry) {
+    return {
+      name: nip89Entry.name,
+      method: 'nip89_pubkey',
+      confidence: 'medium',
+      address: nip89Entry.address,
+    };
+  }
+
+  // Tier 4: Fingerprint matching
+  for (const fp of fingerprints) {
+    if (matchFingerprint(event, fp)) {
+      return {
+        name: fp.app_name,
+        method: 'fingerprint',
+        confidence: 'low',
+      };
+    }
+  }
+
+  return null;
+}
+
+function matchFingerprint(event: NostrEvent, fp: AppFingerprint): boolean {
+  // Check pubkey prefix match
+  if (fp.pubkey_prefix?.length) {
+    if (fp.pubkey_prefix.some(prefix => event.pubkey.startsWith(prefix))) {
+      return true;
+    }
+  }
+
+  // Check tag pattern match (all patterns must match)
+  if (fp.tag_pattern?.length) {
+    const allMatch = fp.tag_pattern.every(pattern => {
+      return event.tags.some(tag => {
+        if (tag[0] !== pattern.tag) return false;
+        if (pattern.value && tag[1] !== pattern.value) return false;
+        return true;
+      });
+    });
+    if (allMatch) return true;
+  }
+
+  // Check content pattern match (any pattern matches)
+  if (fp.content_pattern?.length) {
+    if (fp.content_pattern.some(pattern => event.content.includes(pattern))) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -10,8 +10,14 @@ import {
   getTopPubkeysForErrors,
   getTimeRange,
   getDistinctRelays,
+  getAttributionSummary,
+  getPubkeyDistribution,
+  getTagFrequency,
+  getSampleEvents,
+  getAppTrend,
+  getAllAppTrends,
 } from '../db/index.js';
-import { KIND_NAMES, STATUS_THRESHOLDS, GITHUB_REPO, DEFAULT_KINDS, PUBLISH_RELAYS } from '../config.js';
+import { KIND_NAMES, STATUS_THRESHOLDS, GITHUB_REPO, DEFAULT_KINDS } from '../config.js';
 import { which } from '../util.js';
 
 // --- Types ---
@@ -21,12 +27,17 @@ interface KindFindings {
   schema_key: string;
   total: number; valid: number; invalid: number; error_rate: number;
   top_errors: Array<{ keyword: string | null; path: string | null; message: string; count: number }>;
-  by_app: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string }>;
+  semantic_warnings: Array<{ check_name: string; message: string; count: number }>;
+  by_app: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string; attribution_method?: string }>;
+  unique_pubkeys: number;
 }
 
 interface AppFindings {
   total_events: number; total_valid: number; total_invalid: number; error_rate: number;
   kinds_published: number[];
+  unique_pubkeys: number;
+  is_widespread: boolean;
+  attribution_method?: string;
   violations: Array<{
     kind: number; keyword: string | null; path: string | null;
     message: string; count: number; sample_event_ids: string[];
@@ -41,6 +52,18 @@ interface ErrorPattern {
   top_pubkeys: string[];
 }
 
+interface TrendDataPoint {
+  date: string;
+  error_rate: number;
+  events: number;
+  invalid: number;
+}
+
+interface AppTrend {
+  direction: 'improving' | 'worsening' | 'stable' | 'insufficient_data';
+  data_points: TrendDataPoint[];
+}
+
 interface Findings {
   version: number;
   generated_at: string;
@@ -50,9 +73,11 @@ interface Findings {
     relays: string[];
     first_event_at: string | null; last_event_at: string | null;
   };
+  attribution_summary: Record<string, number>;
   by_kind: Record<string, KindFindings>;
   by_app: Record<string, AppFindings>;
   error_patterns: ErrorPattern[];
+  trends: { by_app: Record<string, AppTrend> };
 }
 
 export interface ExportCommandOptions {
@@ -62,11 +87,10 @@ export interface ExportCommandOptions {
 
 // --- Helpers ---
 
-function computeStatus(valid: number, invalid: number): string {
-  const validated = valid + invalid;
-  if (validated < STATUS_THRESHOLDS.MIN_EVENTS) return 'u';
+function computeStatus(total: number, invalid: number): string {
+  if (total < STATUS_THRESHOLDS.MIN_EVENTS) return 'u';
   if (invalid === 0) return 'y';
-  if (invalid / validated <= STATUS_THRESHOLDS.ALMOST_MAX) return 'a';
+  if (invalid / total <= STATUS_THRESHOLDS.ALMOST_MAX) return 'a';
   return 'n';
 }
 
@@ -75,6 +99,24 @@ function ts(unix: number | null): string | null {
 }
 
 // --- Build findings ---
+
+function computeTrendDirection(dataPoints: TrendDataPoint[]): AppTrend['direction'] {
+  if (dataPoints.length < 6) return 'insufficient_data';
+
+  const recent = dataPoints.slice(-3);
+  const previous = dataPoints.slice(-6, -3);
+
+  const avgRecent = recent.reduce((sum, d) => sum + d.error_rate, 0) / recent.length;
+  const avgPrevious = previous.reduce((sum, d) => sum + d.error_rate, 0) / previous.length;
+
+  if (avgPrevious === 0 && avgRecent === 0) return 'stable';
+  if (avgPrevious === 0) return 'worsening';
+
+  const change = (avgRecent - avgPrevious) / avgPrevious;
+  if (change < -0.20) return 'improving';
+  if (change > 0.20) return 'worsening';
+  return 'stable';
+}
 
 function buildFindings(): Findings {
   getDb(); // ensure initialized
@@ -86,6 +128,20 @@ function buildFindings(): Findings {
   const pubkeyRows = getTopPubkeysForErrors();
   const timeRange = getTimeRange();
   const relays = getDistinctRelays();
+  const attrSummary = getAttributionSummary();
+  const pubkeyDist = getPubkeyDistribution();
+
+  // Attribution summary as object
+  const attributionSummary: Record<string, number> = {};
+  for (const row of attrSummary) {
+    attributionSummary[row.method] = row.count;
+  }
+
+  // Index pubkey distribution by client_name+kind
+  const pubkeyIndex2 = new Map<string, number>();
+  for (const row of pubkeyDist) {
+    pubkeyIndex2.set(`${row.client_name}\0${row.kind}`, row.unique_pubkeys);
+  }
 
   // Aggregate totals
   let totalValid = 0, totalInvalid = 0, totalNoSchema = 0;
@@ -95,14 +151,14 @@ function buildFindings(): Findings {
     totalNoSchema += r.no_schema;
   }
 
-  // Build by_kind (use Object.create(null) to prevent prototype pollution from client-controlled keys)
-  const findingsByKind: Record<string, KindFindings> = Object.create(null);
+  // Build by_kind
+  const findingsByKind: Record<string, KindFindings> = {};
   for (const r of byKind) {
     const validated = r.valid + r.invalid;
     const errorRate = validated > 0 ? r.invalid / validated : 0;
 
     // Per-app breakdown for this kind
-    const appBreakdown: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string }> = Object.create(null);
+    const appBreakdown: Record<string, { total: number; valid: number; invalid: number; error_rate: number; status: string; attribution_method?: string }> = {};
     for (const m of matrix) {
       if (m.kind === r.kind) {
         const mValidated = m.valid + m.invalid;
@@ -110,27 +166,54 @@ function buildFindings(): Findings {
         appBreakdown[m.client_name] = {
           total: m.total, valid: m.valid, invalid: m.invalid,
           error_rate: Math.round(mRate * 10000) / 10000,
-          status: computeStatus(m.valid, m.invalid),
+          status: computeStatus(m.total, m.invalid),
         };
       }
     }
 
-    // Top errors for this kind
+    // Top errors for this kind (schema validation errors)
     const kindErrors: Array<{ keyword: string | null; path: string | null; message: string; count: number }> = [];
+    const semanticWarnings: Array<{ check_name: string; message: string; count: number }> = [];
+
     for (const v of violations) {
       if (v.kind === r.kind) {
-        // Deduplicate across apps — aggregate by keyword+path+message
-        const existing = kindErrors.find(
-          e => e.keyword === v.error_keyword && e.path === v.error_path && e.message === v.error_message
+        // Separate semantic warnings from schema errors
+        const isSemantic = v.error_keyword && (
+          v.error_keyword.startsWith('kind0_') ||
+          v.error_keyword.startsWith('kind3_') ||
+          v.error_keyword.startsWith('kind10002_') ||
+          v.error_keyword.startsWith('kind9735_') ||
+          v.error_keyword === 'future_timestamp' ||
+          v.error_keyword === 'timestamp_too_old'
         );
-        if (existing) {
-          existing.count += v.count;
+
+        if (isSemantic) {
+          const existing = semanticWarnings.find(w => w.check_name === v.error_keyword && w.message === v.error_message);
+          if (existing) {
+            existing.count += v.count;
+          } else {
+            semanticWarnings.push({ check_name: v.error_keyword!, message: v.error_message, count: v.count });
+          }
         } else {
-          kindErrors.push({ keyword: v.error_keyword, path: v.error_path, message: v.error_message, count: v.count });
+          const existing = kindErrors.find(
+            e => e.keyword === v.error_keyword && e.path === v.error_path && e.message === v.error_message
+          );
+          if (existing) {
+            existing.count += v.count;
+          } else {
+            kindErrors.push({ keyword: v.error_keyword, path: v.error_path, message: v.error_message, count: v.count });
+          }
         }
       }
     }
     kindErrors.sort((a, b) => b.count - a.count);
+    semanticWarnings.sort((a, b) => b.count - a.count);
+
+    // Count unique pubkeys for this kind
+    let kindPubkeys = 0;
+    for (const [key, count] of pubkeyIndex2) {
+      if (key.endsWith(`\0${r.kind}`)) kindPubkeys += count;
+    }
 
     findingsByKind[String(r.kind)] = {
       name: KIND_NAMES[r.kind] ?? `Kind ${r.kind}`,
@@ -138,17 +221,20 @@ function buildFindings(): Findings {
       total: r.total, valid: r.valid, invalid: r.invalid,
       error_rate: Math.round(errorRate * 10000) / 10000,
       top_errors: kindErrors.slice(0, 10),
+      semantic_warnings: semanticWarnings.slice(0, 10),
       by_app: appBreakdown,
+      unique_pubkeys: kindPubkeys,
     };
   }
 
   // Build by_app
-  const findingsByApp: Record<string, AppFindings> = Object.create(null);
+  const findingsByApp: Record<string, AppFindings> = {};
   for (const m of matrix) {
     if (!findingsByApp[m.client_name]) {
       findingsByApp[m.client_name] = {
         total_events: 0, total_valid: 0, total_invalid: 0, error_rate: 0,
-        kinds_published: [], violations: [],
+        kinds_published: [], unique_pubkeys: 0, is_widespread: false,
+        violations: [],
       };
     }
     const app = findingsByApp[m.client_name];
@@ -156,6 +242,10 @@ function buildFindings(): Findings {
     app.total_valid += m.valid;
     app.total_invalid += m.invalid;
     app.kinds_published.push(m.kind);
+
+    // Add pubkey count for this app+kind
+    const pk = pubkeyIndex2.get(`${m.client_name}\0${m.kind}`) ?? 0;
+    app.unique_pubkeys += pk;
   }
   // Fill violations and compute error rates
   for (const v of violations) {
@@ -168,18 +258,20 @@ function buildFindings(): Findings {
       });
     }
   }
-  for (const app of Object.values(findingsByApp)) {
+  for (const [, app] of Object.entries(findingsByApp)) {
     const validated = app.total_valid + app.total_invalid;
     app.error_rate = validated > 0 ? Math.round(app.total_invalid / validated * 10000) / 10000 : 0;
     app.kinds_published.sort((a, b) => a - b);
     app.violations.sort((a, b) => b.count - a.count);
+    // Widespread = many unique pubkeys (>10 suggests client bug, not individual misconfiguration)
+    app.is_widespread = app.unique_pubkeys > 10;
   }
 
   // Build error_patterns
-  // Index pubkeys by error_keyword+error_path+error_message (aligned with patternMap key)
+  // Index pubkeys by error_keyword+error_path
   const pubkeyIndex = new Map<string, Array<{ pubkey: string; cnt: number }>>();
   for (const p of pubkeyRows) {
-    const key = `${p.error_keyword ?? ''}\0${p.error_path ?? ''}\0${p.error_message}`;
+    const key = `${p.error_keyword ?? ''}\0${p.error_path ?? ''}`;
     if (!pubkeyIndex.has(key)) pubkeyIndex.set(key, []);
     pubkeyIndex.get(key)!.push({ pubkey: p.pubkey, cnt: p.cnt });
   }
@@ -208,36 +300,53 @@ function buildFindings(): Findings {
   }
 
   const errorPatterns = [...patternMap.values()];
-  // Fill top pubkeys (keyed by keyword+path+message, matching patternMap)
+  // Fill top pubkeys
   for (const p of errorPatterns) {
-    const pubkeyKey = `${p.keyword ?? ''}\0${p.path ?? ''}\0${p.message}`;
+    const pubkeyKey = `${p.keyword ?? ''}\0${p.path ?? ''}`;
     const pubs = pubkeyIndex.get(pubkeyKey) ?? [];
     p.top_pubkeys = pubs.slice(0, 5).map(x => x.pubkey);
   }
   errorPatterns.sort((a, b) => b.total_count - a.total_count);
 
+  // Build trends
+  const trendsByApp: Record<string, AppTrend> = {};
+  const allApps = Object.keys(findingsByApp);
+  for (const appName of allApps) {
+    const rawTrend = getAppTrend(appName);
+    const dataPoints: TrendDataPoint[] = rawTrend.map(t => ({
+      date: t.period,
+      error_rate: t.error_rate,
+      events: t.total,
+      invalid: t.invalid,
+    }));
+    trendsByApp[appName] = {
+      direction: computeTrendDirection(dataPoints),
+      data_points: dataPoints,
+    };
+  }
+
   return {
-    version: 1,
+    version: 2,
     generated_at: new Date().toISOString(),
     scan_coverage: {
       total_events: total, total_valid: totalValid, total_invalid: totalInvalid, total_no_schema: totalNoSchema,
-      // Include all configured kinds (not just those with events) so zero-hit kinds are visible
-      kinds_scanned: [...new Set([...DEFAULT_KINDS, ...byKind.map(r => r.kind)])].sort((a, b) => a - b),
+      kinds_scanned: byKind.map(r => r.kind).sort((a, b) => a - b),
       relays,
       first_event_at: ts(timeRange.first_at),
       last_event_at: ts(timeRange.last_at),
     },
+    attribution_summary: attributionSummary,
     by_kind: findingsByKind,
     by_app: findingsByApp,
     error_patterns: errorPatterns,
+    trends: { by_app: trendsByApp },
   };
 }
 
 // --- HTML dashboard ---
 
 function generateHtml(findings: Findings): string {
-  // Escape </script> sequences to prevent XSS breakout from inline <script> tag.
-  // Also escape <!-- to prevent HTML comment injection.
+  // Escape for safe embedding in HTML: replace </ to prevent </script> breakout
   const data = JSON.stringify(findings).replace(/</g, '\\u003c');
   return `<!DOCTYPE html>
 <html lang="en">
@@ -246,8 +355,8 @@ function generateHtml(findings: Findings): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sherlock — Nostr Schema Validation Report</title>
 <style>
-:root { --bg: #fff; --fg: #1a1a1a; --muted: #666; --border: #e0e0e0; --hover: #f5f5f5; --accent: #4a90d9; --green: #22863a; --yellow: #b08800; --red: #cb2431; --badge-bg: #f0f0f0; }
-@media(prefers-color-scheme:dark) { :root { --bg: #0d1117; --fg: #c9d1d9; --muted: #8b949e; --border: #30363d; --hover: #161b22; --accent: #58a6ff; --green: #3fb950; --yellow: #d29922; --red: #f85149; --badge-bg: #21262d; } }
+:root { --bg: #fff; --fg: #1a1a1a; --muted: #666; --border: #e0e0e0; --hover: #f5f5f5; --accent: #4a90d9; --green: #22863a; --yellow: #b08800; --red: #cb2431; --badge-bg: #f0f0f0; --warn-bg: #fff8e1; }
+@media(prefers-color-scheme:dark) { :root { --bg: #0d1117; --fg: #c9d1d9; --muted: #8b949e; --border: #30363d; --hover: #161b22; --accent: #58a6ff; --green: #3fb950; --yellow: #d29922; --red: #f85149; --badge-bg: #21262d; --warn-bg: #2d2200; } }
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--fg); line-height: 1.5; max-width: 1200px; margin: 0 auto; padding: 20px; }
 h1 { font-size: 1.5rem; margin-bottom: 4px; }
@@ -267,11 +376,12 @@ table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
 th { text-align: left; padding: 8px 12px; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; }
 td { padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
 tr:hover { background: var(--hover); }
+tr.expandable { cursor: pointer; }
+tr.expandable td:first-child::before { content: "\\25b8 "; color: var(--muted); }
+tr.expandable.open td:first-child::before { content: "\\25be "; }
 tr.detail { display: none; }
 tr.detail.open { display: table-row; }
 tr.detail td { padding-left: 32px; background: var(--hover); }
-.expand-btn { background: none; border: none; cursor: pointer; color: var(--muted); font-size: 0.85rem; padding: 0 4px 0 0; vertical-align: middle; }
-.expand-btn:hover { color: var(--fg); }
 .status { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
 .status-y { background: var(--green); }
 .status-a { background: var(--yellow); }
@@ -279,6 +389,9 @@ tr.detail td { padding-left: 32px; background: var(--hover); }
 .status-u { background: var(--muted); }
 .mono { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.8rem; }
 .badge { display: inline-block; padding: 1px 6px; border-radius: 4px; background: var(--badge-bg); font-size: 0.75rem; margin: 1px; }
+.badge-method { font-size: 0.65rem; padding: 0 4px; }
+.badge-warn { background: var(--warn-bg); color: var(--yellow); }
+.badge-pubkey { font-size: 0.7rem; color: var(--muted); margin-left: 4px; }
 .rate { font-weight: 600; }
 .rate-good { color: var(--green); }
 .rate-warn { color: var(--yellow); }
@@ -287,6 +400,16 @@ tr.detail td { padding-left: 32px; background: var(--hover); }
 .copy { cursor: pointer; color: var(--accent); }
 .copy:hover { text-decoration: underline; }
 .empty { text-align: center; padding: 40px; color: var(--muted); }
+.sparkline { display: inline-flex; align-items: flex-end; gap: 1px; height: 24px; vertical-align: middle; }
+.sparkline span { display: inline-block; width: 4px; min-height: 1px; background: var(--accent); border-radius: 1px 1px 0 0; }
+.sparkline span.bar-bad { background: var(--red); }
+.sparkline span.bar-warn { background: var(--yellow); }
+.sparkline span.bar-good { background: var(--green); }
+.trend-arrow { font-weight: 700; margin-left: 4px; }
+.trend-improving { color: var(--green); }
+.trend-worsening { color: var(--red); }
+.trend-stable { color: var(--muted); }
+.trend-insufficient { color: var(--muted); font-style: italic; }
 </style>
 </head>
 <body>
@@ -299,26 +422,57 @@ tr.detail td { padding-left: 32px; background: var(--hover); }
   <button class="tab active" data-tab="kind">By Kind</button>
   <button class="tab" data-tab="app">By App</button>
   <button class="tab" data-tab="errors">Errors</button>
+  <button class="tab" data-tab="trends">Trends</button>
 </div>
 
 <div class="panel active" id="panel-kind"></div>
 <div class="panel" id="panel-app"></div>
 <div class="panel" id="panel-errors"></div>
+<div class="panel" id="panel-trends"></div>
 
 <script>
-const FINDINGS = ${data};
+var FINDINGS = ${data};
 
-const KIND_NAMES = ${JSON.stringify(KIND_NAMES).replace(/</g, '\\u003c')};
+var KIND_NAMES = ${JSON.stringify(KIND_NAMES)};
 
-function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function esc(s) { if (s == null) return ''; var d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
 function pct(n, t) { return t > 0 ? (n/t*100).toFixed(1) + '%' : '0.0%'; }
 function rateClass(rate) { return rate === 0 ? 'rate-good' : rate <= 0.05 ? 'rate-warn' : 'rate-bad'; }
 function statusDot(s) { return '<span class="status status-' + s + '" title="' + ({y:'clean',a:'almost',n:'broken',u:'unknown'}[s]||s) + '"></span>'; }
-function shortId(id) { return id ? id.slice(0, 8) + '…' : ''; }
+function shortId(id) { return id ? id.slice(0, 8) + '\\u2026' : ''; }
+function methodBadge(m) {
+  if (!m) return '';
+  var labels = {client_tag:'tag',nip89_pubkey:'nip89',fingerprint:'fp'};
+  return ' <span class="badge badge-method">' + (labels[m]||m) + '</span>';
+}
+function trendArrow(dir) {
+  var arrows = {improving:'\\u2193',worsening:'\\u2191',stable:'\\u2192',insufficient_data:'?'};
+  var cls = 'trend-' + (dir === 'insufficient_data' ? 'insufficient' : dir);
+  return '<span class="trend-arrow ' + cls + '">' + (arrows[dir]||'?') + '</span>';
+}
+function sparkline(points) {
+  if (!points || !points.length) return '';
+  var maxRate = 0;
+  for (var i=0;i<points.length;i++) { if (points[i].error_rate > maxRate) maxRate = points[i].error_rate; }
+  if (maxRate === 0) maxRate = 1;
+  var html = '<span class="sparkline">';
+  var recent = points.slice(-30);
+  for (var i=0;i<recent.length;i++) {
+    var h = Math.max(1, Math.round(recent[i].error_rate / maxRate * 24));
+    var cls = recent[i].error_rate === 0 ? 'bar-good' : recent[i].error_rate <= 0.05 ? 'bar-warn' : 'bar-bad';
+    html += '<span class="' + cls + '" style="height:' + h + 'px" title="' + esc(recent[i].date) + ': ' + (recent[i].error_rate*100).toFixed(1) + '%"></span>';
+  }
+  html += '</span>';
+  return html;
+}
+function copyText(text) { navigator.clipboard.writeText(text); }
 
 // Coverage
 (function() {
-  const c = FINDINGS.scan_coverage;
+  var c = FINDINGS.scan_coverage;
+  var a = FINDINGS.attribution_summary || {};
+  var attrParts = Object.keys(a).filter(function(k){return k!=='unattributed'}).map(function(k){return k + ': ' + a[k]});
+  var attrText = attrParts.length ? attrParts.join(', ') : 'none';
   document.getElementById('coverage').innerHTML = [
     stat('Events', c.total_events.toLocaleString()),
     stat('Valid', c.total_valid.toLocaleString()),
@@ -326,15 +480,16 @@ function shortId(id) { return id ? id.slice(0, 8) + '…' : ''; }
     stat('No Schema', c.total_no_schema.toLocaleString()),
     stat('Kinds', c.kinds_scanned.length),
     stat('Relays', c.relays.length),
+    stat('Attributed', attrText),
   ].join('');
   function stat(label, value) { return '<div class="stat"><span class="label">' + label + '</span><span class="value">' + value + '</span></div>'; }
 })();
 
 // Tabs
-document.querySelectorAll('.tab').forEach(tab => {
-  tab.addEventListener('click', () => {
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+document.querySelectorAll('.tab').forEach(function(tab) {
+  tab.addEventListener('click', function() {
+    document.querySelectorAll('.tab').forEach(function(t) { t.classList.remove('active'); });
+    document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
     tab.classList.add('active');
     document.getElementById('panel-' + tab.dataset.tab).classList.add('active');
   });
@@ -342,20 +497,32 @@ document.querySelectorAll('.tab').forEach(tab => {
 
 // By Kind
 (function() {
-  const bk = FINDINGS.by_kind;
-  const kinds = Object.keys(bk).sort((a,b) => Number(a) - Number(b));
+  var bk = FINDINGS.by_kind;
+  var kinds = Object.keys(bk).sort(function(a,b) { return Number(a) - Number(b); });
   if (!kinds.length) { document.getElementById('panel-kind').innerHTML = '<div class="empty">No data</div>'; return; }
-  let html = '<table><thead><tr><th>Kind</th><th>Name</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Top Error</th></tr></thead><tbody>';
-  for (const k of kinds) {
-    const d = bk[k];
-    const topErr = d.top_errors[0];
-    const rc = rateClass(d.error_rate);
-    html += '<tr><td><button type="button" class="expand-btn" aria-expanded="false">&#9656;</button>' + k + '</td><td>' + esc(d.name) + '</td><td>' + d.total.toLocaleString() + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '—') + '</td></tr>';
+  var html = '<table><thead><tr><th>Kind</th><th>Name</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Top Error</th></tr></thead><tbody>';
+  for (var ki = 0; ki < kinds.length; ki++) {
+    var k = kinds[ki];
+    var d = bk[k];
+    var topErr = d.top_errors[0];
+    var rc = rateClass(d.error_rate);
+    var warnCount = d.semantic_warnings ? d.semantic_warnings.reduce(function(s,w){return s+w.count},0) : 0;
+    var warnBadge = warnCount > 0 ? ' <span class="badge badge-warn">' + warnCount + ' warns</span>' : '';
+    var pkBadge = d.unique_pubkeys ? '<span class="badge-pubkey">' + d.unique_pubkeys + ' pubkeys</span>' : '';
+    html += '<tr class="expandable" data-kind="' + k + '"><td>' + k + '</td><td>' + esc(d.name) + warnBadge + '</td><td>' + d.total.toLocaleString() + ' ' + pkBadge + '</td><td>' + d.valid.toLocaleString() + '</td><td>' + d.invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.invalid, d.valid + d.invalid) + '</td><td class="truncate mono">' + (topErr ? esc(topErr.keyword + ' @ ' + (topErr.path||'/')) : '\\u2014') + '</td></tr>';
     // Detail rows: per-app breakdown
-    const apps = Object.keys(d.by_app).sort((a,b) => d.by_app[b].total - d.by_app[a].total);
-    for (const app of apps) {
-      const a = d.by_app[app];
-      html += '<tr class="detail"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
+    var apps = Object.keys(d.by_app).sort(function(a,b) { return d.by_app[b].total - d.by_app[a].total; });
+    for (var ai = 0; ai < apps.length; ai++) {
+      var app = apps[ai];
+      var a = d.by_app[app];
+      html += '<tr class="detail" data-parent="' + k + '"><td></td><td>' + statusDot(a.status) + ' ' + esc(app) + methodBadge(a.attribution_method) + '</td><td>' + a.total.toLocaleString() + '</td><td>' + a.valid.toLocaleString() + '</td><td>' + a.invalid.toLocaleString() + '</td><td class="rate ' + rateClass(a.error_rate) + '">' + pct(a.invalid, a.valid + a.invalid) + '</td><td></td></tr>';
+    }
+    // Semantic warning detail rows
+    if (d.semantic_warnings && d.semantic_warnings.length) {
+      for (var wi = 0; wi < d.semantic_warnings.length; wi++) {
+        var w = d.semantic_warnings[wi];
+        html += '<tr class="detail" data-parent="' + k + '"><td></td><td colspan="4" class="mono"><span class="badge badge-warn">warn</span> ' + esc(w.check_name) + ': ' + esc(w.message) + '</td><td>' + w.count + '</td><td></td></tr>';
+      }
     }
   }
   html += '</tbody></table>';
@@ -364,17 +531,25 @@ document.querySelectorAll('.tab').forEach(tab => {
 
 // By App
 (function() {
-  const ba = FINDINGS.by_app;
-  const apps = Object.keys(ba).sort((a,b) => ba[b].total_events - ba[a].total_events);
+  var ba = FINDINGS.by_app;
+  var trends = FINDINGS.trends ? FINDINGS.trends.by_app : {};
+  var apps = Object.keys(ba).sort(function(a,b) { return ba[b].total_events - ba[a].total_events; });
   if (!apps.length) { document.getElementById('panel-app').innerHTML = '<div class="empty">No data</div>'; return; }
-  let html = '<table><thead><tr><th>App</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Kinds</th></tr></thead><tbody>';
-  for (const app of apps) {
-    const d = ba[app];
-    const rc = rateClass(d.error_rate);
-    html += '<tr><td><button type="button" class="expand-btn" aria-expanded="false">&#9656;</button>' + esc(app) + '</td><td>' + d.total_events.toLocaleString() + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + d.kinds_published.map(k => '<span class="badge">' + k + '</span>').join('') + '</td></tr>';
+  var html = '<table><thead><tr><th>App</th><th>Events</th><th>Valid</th><th>Invalid</th><th>Error Rate</th><th>Trend</th><th>Kinds</th></tr></thead><tbody>';
+  for (var ai = 0; ai < apps.length; ai++) {
+    var app = apps[ai];
+    var d = ba[app];
+    var rc = rateClass(d.error_rate);
+    var appId = 'app-' + ai;
+    var pkBadge = d.unique_pubkeys ? '<span class="badge-pubkey">' + d.unique_pubkeys + ' pubkeys</span>' : '';
+    var trend = trends[app];
+    var trendHtml = trend ? trendArrow(trend.direction) + ' ' + sparkline(trend.data_points) : '';
+    html += '<tr class="expandable" data-app="' + appId + '"><td>' + esc(app) + methodBadge(d.attribution_method) + '</td><td>' + d.total_events.toLocaleString() + ' ' + pkBadge + '</td><td>' + d.total_valid.toLocaleString() + '</td><td>' + d.total_invalid.toLocaleString() + '</td><td class="rate ' + rc + '">' + pct(d.total_invalid, d.total_valid + d.total_invalid) + '</td><td>' + trendHtml + '</td><td>' + d.kinds_published.map(function(k) { return '<span class="badge">' + k + '</span>'; }).join('') + '</td></tr>';
     // Detail rows: violations
-    for (const v of d.violations.slice(0, 10)) {
-      html += '<tr class="detail"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td class="mono">' + v.sample_event_ids.map(id => '<span class="copy" data-copy="' + id + '" title="Click to copy ' + id + '">' + shortId(id) + '</span>').join(' ') + '</td></tr>';
+    for (var vi = 0; vi < Math.min(d.violations.length, 10); vi++) {
+      var v = d.violations[vi];
+      var name = KIND_NAMES[v.kind] || 'kind:' + v.kind;
+      html += '<tr class="detail" data-parent="' + appId + '"><td></td><td colspan="2" class="mono">' + esc((v.keyword||'') + ' @ ' + (v.path||'/')) + '</td><td>' + v.count + '</td><td class="mono truncate">' + esc(v.message) + '</td><td></td><td class="mono">' + v.sample_event_ids.map(function(id) { return '<span class="copy" data-copy="' + esc(id) + '" title="Click to copy ' + esc(id) + '">' + shortId(id) + '</span>'; }).join(' ') + '</td></tr>';
     }
   }
   html += '</tbody></table>';
@@ -383,54 +558,61 @@ document.querySelectorAll('.tab').forEach(tab => {
 
 // Errors
 (function() {
-  const errs = FINDINGS.error_patterns;
+  var errs = FINDINGS.error_patterns;
   if (!errs.length) { document.getElementById('panel-errors').innerHTML = '<div class="empty">No errors</div>'; return; }
-  let html = '<table><thead><tr><th>Error</th><th>Path</th><th>Message</th><th>Count</th><th>Kinds</th><th>Apps</th><th>Top Pubkeys</th></tr></thead><tbody>';
-  for (const e of errs.slice(0, 50)) {
-    html += '<tr><td class="mono">' + esc(e.keyword||'—') + '</td><td class="mono">' + esc(e.path||'/') + '</td><td class="truncate">' + esc(e.message) + '</td><td>' + e.total_count.toLocaleString() + '</td><td>' + e.affected_kinds.map(k => '<span class="badge">' + k + '</span>').join('') + '</td><td>' + e.affected_apps.map(a => '<span class="badge">' + esc(a) + '</span>').join('') + '</td><td class="mono">' + e.top_pubkeys.map(p => '<span class="copy" data-copy="' + p + '" title="' + p + '">' + p.slice(0,8) + '…</span>').join(' ') + '</td></tr>';
+  var html = '<table><thead><tr><th>Error</th><th>Path</th><th>Message</th><th>Count</th><th>Kinds</th><th>Apps</th><th>Top Pubkeys</th></tr></thead><tbody>';
+  for (var i = 0; i < Math.min(errs.length, 50); i++) {
+    var e = errs[i];
+    html += '<tr><td class="mono">' + esc(e.keyword||'\\u2014') + '</td><td class="mono">' + esc(e.path||'/') + '</td><td class="truncate">' + esc(e.message) + '</td><td>' + e.total_count.toLocaleString() + '</td><td>' + e.affected_kinds.map(function(k) { return '<span class="badge">' + k + '</span>'; }).join('') + '</td><td>' + e.affected_apps.map(function(a) { return '<span class="badge">' + esc(a) + '</span>'; }).join('') + '</td><td class="mono">' + e.top_pubkeys.map(function(p) { return '<span class="copy" data-copy="' + esc(p) + '" title="' + esc(p) + '">' + p.slice(0,8) + '\\u2026</span>'; }).join(' ') + '</td></tr>';
   }
   html += '</tbody></table>';
   document.getElementById('panel-errors').innerHTML = html;
 })();
 
-// Expand/collapse detail rows via sibling traversal
-document.addEventListener('click', function(e) {
-  var btn = e.target.closest('.expand-btn');
-  if (!btn) return;
-  var row = btn.closest('tr');
-  if (!row) return;
-  var expanded = btn.getAttribute('aria-expanded') === 'true';
-  btn.setAttribute('aria-expanded', String(!expanded));
-  btn.innerHTML = expanded ? '&#9656;' : '&#9662;';
-  var sibling = row.nextElementSibling;
-  while (sibling && sibling.classList.contains('detail')) {
-    sibling.classList.toggle('open');
-    sibling = sibling.nextElementSibling;
+// Trends
+(function() {
+  var trends = FINDINGS.trends ? FINDINGS.trends.by_app : {};
+  var apps = Object.keys(trends).filter(function(a) { return trends[a].data_points.length > 0; });
+  apps.sort(function(a,b) {
+    var da = {improving:0,worsening:1,stable:2,insufficient_data:3};
+    var diff = (da[trends[a].direction]||3) - (da[trends[b].direction]||3);
+    if (diff !== 0) return diff;
+    return trends[b].data_points.length - trends[a].data_points.length;
+  });
+  if (!apps.length) { document.getElementById('panel-trends').innerHTML = '<div class="empty">No trend data yet. Run multiple scans to see trends.</div>'; return; }
+  var html = '<table><thead><tr><th>App</th><th>Direction</th><th>Sparkline (last 30d)</th><th>Latest Error Rate</th><th>Data Points</th></tr></thead><tbody>';
+  for (var i = 0; i < apps.length; i++) {
+    var app = apps[i];
+    var t = trends[app];
+    var last = t.data_points[t.data_points.length - 1];
+    var latestRate = last ? last.error_rate : 0;
+    html += '<tr><td>' + esc(app) + '</td><td>' + trendArrow(t.direction) + ' ' + esc(t.direction) + '</td><td>' + sparkline(t.data_points) + '</td><td class="rate ' + rateClass(latestRate) + '">' + (latestRate*100).toFixed(1) + '%</td><td>' + t.data_points.length + '</td></tr>';
   }
-});
+  html += '</tbody></table>';
+  document.getElementById('panel-trends').innerHTML = html;
+})();
 
-// Copy to clipboard via delegated handler
+// Expand/collapse rows + copy handler (delegated)
 document.addEventListener('click', function(e) {
-  var el = e.target.closest('[data-copy]');
-  if (el) navigator.clipboard.writeText(el.dataset.copy);
+  // Copy handler
+  var copyEl = e.target.closest('.copy[data-copy]');
+  if (copyEl) {
+    navigator.clipboard.writeText(copyEl.dataset.copy);
+    return;
+  }
+  // Expand/collapse
+  var row = e.target.closest('tr.expandable');
+  if (!row) return;
+  var key = row.dataset.kind || row.dataset.app;
+  row.classList.toggle('open');
+  row.closest('tbody').querySelectorAll('tr.detail[data-parent="' + key + '"]').forEach(function(r) { r.classList.toggle('open'); });
 });
 </script>
 </body>
 </html>`;
 }
 
-// --- Nostr publishing helpers ---
-
-/** Strip newlines and control chars from relay-derived text for plain-text notes. */
-function sanitizeText(s: string): string {
-  return s.replace(/[\r\n\t]+/g, ' ').trim();
-}
-
-/** Escape pipe and strip newlines for markdown table cells. */
-function mdCell(s: string): string {
-  return s.replace(/[\r\n\t]+/g, ' ').replace(/\|/g, '\\|').trim();
-}
-
+// --- Nostr publishing ---
 
 function buildKind1Summary(findings: Findings): string {
   const c = findings.scan_coverage;
@@ -465,7 +647,7 @@ function buildKind1Summary(findings: Findings): string {
   if (namedApps.length > 0) {
     text += `Apps with violations:\n`;
     for (const [name, data] of namedApps) {
-      text += `• ${sanitizeText(name)}: ${data.total_invalid} invalid of ${data.total_events}\n`;
+      text += `• ${name}: ${data.total_invalid} invalid of ${data.total_events}\n`;
     }
     text += '\n';
   }
@@ -510,7 +692,7 @@ function buildKind30023Content(findings: Findings): string {
     md += `|-----|--------|-------|---------|------------|\n`;
     for (const [name, data] of namedApps) {
       const ratePct = (data.error_rate * 100).toFixed(1);
-      md += `| ${mdCell(name)} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
+      md += `| ${name} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
     }
     md += '\n';
   }
@@ -545,6 +727,12 @@ async function publishToNostr(findings: Findings): Promise<void> {
     return;
   }
 
+  const publishRelays = [
+    'wss://relay.damus.io',
+    'wss://nos.lol',
+    'wss://relay.nostr.band',
+  ];
+
   const now = Math.floor(Date.now() / 1000);
   const dateTag = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
 
@@ -561,7 +749,7 @@ async function publishToNostr(findings: Findings): Promise<void> {
       '-c', kind1Content,
       '-t', 't=sherlock',
       '-t', 't=nostrability',
-      ...PUBLISH_RELAYS,
+      ...publishRelays,
     ];
     const result1 = execFileSync(nakPath, kind1Args, { encoding: 'utf-8', timeout: 30000, env: nakEnv });
     console.log('  kind:1 published:', result1.trim().slice(0, 80));
@@ -584,7 +772,7 @@ async function publishToNostr(findings: Findings): Promise<void> {
       '-t', `published_at=${String(now)}`,
       '-t', 't=sherlock',
       '-t', 't=nostrability',
-      ...PUBLISH_RELAYS,
+      ...publishRelays,
     ];
     const result2 = execFileSync(nakPath, kind30023Args, { encoding: 'utf-8', timeout: 30000, env: nakEnv });
     console.log('  kind:30023 published:', result2.trim().slice(0, 80));

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -11,7 +11,8 @@ import {
   getTimeRange,
   getDistinctRelays,
   getAttributionSummary,
-  getPubkeyDistribution,
+  getPubkeyCountByKind,
+  getPubkeyCountByApp,
   getTagFrequency,
   getSampleEvents,
   getAppTrend,
@@ -129,7 +130,8 @@ function buildFindings(): Findings {
   const timeRange = getTimeRange();
   const relays = getDistinctRelays();
   const attrSummary = getAttributionSummary();
-  const pubkeyDist = getPubkeyDistribution();
+  const pubkeyByKind = getPubkeyCountByKind();
+  const pubkeyByApp = getPubkeyCountByApp();
 
   // Attribution summary as object
   const attributionSummary: Record<string, number> = {};
@@ -137,10 +139,14 @@ function buildFindings(): Findings {
     attributionSummary[row.method] = row.count;
   }
 
-  // Index pubkey distribution by client_name+kind
-  const pubkeyIndex2 = new Map<string, number>();
-  for (const row of pubkeyDist) {
-    pubkeyIndex2.set(`${row.client_name}\0${row.kind}`, row.unique_pubkeys);
+  // Index pubkey counts at correct aggregation level
+  const kindPubkeyMap = new Map<number, number>();
+  for (const row of pubkeyByKind) {
+    kindPubkeyMap.set(row.kind, row.unique_pubkeys);
+  }
+  const appPubkeyMap = new Map<string, number>();
+  for (const row of pubkeyByApp) {
+    appPubkeyMap.set(row.client_name, row.unique_pubkeys);
   }
 
   // Aggregate totals
@@ -167,6 +173,7 @@ function buildFindings(): Findings {
           total: m.total, valid: m.valid, invalid: m.invalid,
           error_rate: Math.round(mRate * 10000) / 10000,
           status: computeStatus(m.total, m.invalid),
+          attribution_method: m.attribution_method ?? undefined,
         };
       }
     }
@@ -177,17 +184,8 @@ function buildFindings(): Findings {
 
     for (const v of violations) {
       if (v.kind === r.kind) {
-        // Separate semantic warnings from schema errors
-        const isSemantic = v.error_keyword && (
-          v.error_keyword.startsWith('kind0_') ||
-          v.error_keyword.startsWith('kind3_') ||
-          v.error_keyword.startsWith('kind10002_') ||
-          v.error_keyword.startsWith('kind9735_') ||
-          v.error_keyword === 'future_timestamp' ||
-          v.error_keyword === 'timestamp_too_old'
-        );
-
-        if (isSemantic) {
+        // Separate semantic warnings from schema errors using severity field
+        if (v.severity === 'warning') {
           const existing = semanticWarnings.find(w => w.check_name === v.error_keyword && w.message === v.error_message);
           if (existing) {
             existing.count += v.count;
@@ -209,11 +207,8 @@ function buildFindings(): Findings {
     kindErrors.sort((a, b) => b.count - a.count);
     semanticWarnings.sort((a, b) => b.count - a.count);
 
-    // Count unique pubkeys for this kind
-    let kindPubkeys = 0;
-    for (const [key, count] of pubkeyIndex2) {
-      if (key.endsWith(`\0${r.kind}`)) kindPubkeys += count;
-    }
+    // Unique pubkeys at the kind level (properly deduplicated)
+    const kindPubkeys = kindPubkeyMap.get(r.kind) ?? 0;
 
     findingsByKind[String(r.kind)] = {
       name: KIND_NAMES[r.kind] ?? `Kind ${r.kind}`,
@@ -234,6 +229,7 @@ function buildFindings(): Findings {
       findingsByApp[m.client_name] = {
         total_events: 0, total_valid: 0, total_invalid: 0, error_rate: 0,
         kinds_published: [], unique_pubkeys: 0, is_widespread: false,
+        attribution_method: m.attribution_method ?? undefined,
         violations: [],
       };
     }
@@ -242,10 +238,10 @@ function buildFindings(): Findings {
     app.total_valid += m.valid;
     app.total_invalid += m.invalid;
     app.kinds_published.push(m.kind);
-
-    // Add pubkey count for this app+kind
-    const pk = pubkeyIndex2.get(`${m.client_name}\0${m.kind}`) ?? 0;
-    app.unique_pubkeys += pk;
+  }
+  // Set unique pubkey counts at app aggregation level (properly deduplicated)
+  for (const [appName, app] of Object.entries(findingsByApp)) {
+    app.unique_pubkeys = appPubkeyMap.get(appName) ?? 0;
   }
   // Fill violations and compute error rates
   for (const v of violations) {
@@ -600,12 +596,16 @@ document.addEventListener('click', function(e) {
     navigator.clipboard.writeText(copyEl.dataset.copy);
     return;
   }
-  // Expand/collapse
+  // Expand/collapse via sibling traversal
   var row = e.target.closest('tr.expandable');
   if (!row) return;
   var key = row.dataset.kind || row.dataset.app;
   row.classList.toggle('open');
-  row.closest('tbody').querySelectorAll('tr.detail[data-parent="' + key + '"]').forEach(function(r) { r.classList.toggle('open'); });
+  var sib = row.nextElementSibling;
+  while (sib && sib.classList.contains('detail') && sib.dataset.parent === key) {
+    sib.classList.toggle('open');
+    sib = sib.nextElementSibling;
+  }
 });
 </script>
 </body>

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -614,6 +614,11 @@ document.addEventListener('click', function(e) {
 
 // --- Nostr publishing ---
 
+/** Sanitize a string for safe interpolation into Nostr kind:1/kind:30023 text. */
+function sanitizeText(s: string): string {
+  return s.replace(/[\r\n|]/g, ' ').trim();
+}
+
 function buildKind1Summary(findings: Findings): string {
   const c = findings.scan_coverage;
   const totalValidated = c.total_valid + c.total_invalid;
@@ -647,7 +652,7 @@ function buildKind1Summary(findings: Findings): string {
   if (namedApps.length > 0) {
     text += `Apps with violations:\n`;
     for (const [name, data] of namedApps) {
-      text += `• ${name}: ${data.total_invalid} invalid of ${data.total_events}\n`;
+      text += `• ${sanitizeText(name)}: ${data.total_invalid} invalid of ${data.total_events}\n`;
     }
     text += '\n';
   }
@@ -692,7 +697,7 @@ function buildKind30023Content(findings: Findings): string {
     md += `|-----|--------|-------|---------|------------|\n`;
     for (const [name, data] of namedApps) {
       const ratePct = (data.error_rate * 100).toFixed(1);
-      md += `| ${name} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
+      md += `| ${sanitizeText(name)} | ${data.total_events.toLocaleString()} | ${data.total_valid.toLocaleString()} | ${data.total_invalid.toLocaleString()} | ${ratePct}% |\n`;
     }
     md += '\n';
   }

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -3,6 +3,7 @@ import {
   getViolationsByClient,
   getViolationsByError,
   getRecentViolations,
+  getAllAppTrends,
   getDb,
 } from '../db/index.js';
 
@@ -33,8 +34,11 @@ export function reportCommand(opts: ReportCommandOptions): void {
     case 'recent':
       reportRecent(format, limit);
       break;
+    case 'trend':
+      reportByTrend(format, limit);
+      break;
     default:
-      console.error(`Unknown grouping: ${groupBy}. Use: kind, client, error, recent`);
+      console.error(`Unknown grouping: ${groupBy}. Use: kind, client, error, recent, trend`);
       process.exit(1);
   }
 }
@@ -163,6 +167,40 @@ function reportRecent(format: string, limit?: number): void {
     const msg = row.error_message.length > 38 ? row.error_message.slice(0, 35) + '...' : row.error_message;
     console.log(
       `${row.event_id.slice(0, 10).padEnd(12)} ${String(row.kind).padEnd(8)} ${(row.client_name ?? '-').padEnd(20)} ${msg.padEnd(40)}`
+    );
+  }
+}
+
+function reportByTrend(format: string, limit?: number): void {
+  const rows = getAllAppTrends(30);
+  const display = limit ? rows.slice(0, limit) : rows;
+
+  if (display.length === 0) {
+    console.log('No trend data. Run multiple scans to see trends.');
+    return;
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify(display, null, 2));
+    return;
+  }
+
+  if (format === 'csv') {
+    console.log('client_name,total,invalid,error_rate,first_seen,last_seen,data_points');
+    for (const row of display) {
+      console.log(`${row.client_name},${row.total},${row.invalid},${row.error_rate},${row.first_seen},${row.last_seen},${row.data_points}`);
+    }
+    return;
+  }
+
+  console.log('\nApp Trends (last 30 days)\n');
+  console.log(`${'App'.padEnd(25)} ${'Events'.padStart(8)} ${'Invalid'.padStart(8)} ${'Error%'.padStart(8)} ${'Days'.padStart(6)} ${'Period'.padEnd(24)}`);
+  console.log('-'.repeat(83));
+  for (const row of display) {
+    const name = row.client_name.length > 23 ? row.client_name.slice(0, 20) + '...' : row.client_name;
+    const ratePct = (row.error_rate * 100).toFixed(1) + '%';
+    console.log(
+      `${name.padEnd(25)} ${String(row.total).padStart(8)} ${String(row.invalid).padStart(8)} ${ratePct.padStart(8)} ${String(row.data_points).padStart(6)} ${(row.first_seen + ' - ' + row.last_seen).padEnd(24)}`
     );
   }
 }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,8 +1,10 @@
 import { DEFAULT_RELAYS, DEFAULT_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE } from '../config.js';
 import { fetchEvents, checkNak } from '../fetch/nak.js';
-import { validateEvent, checkSchemaAvailability } from '../validate/engine.js';
-import { extractClientTag } from '../attribution/client-tag.js';
-import { storeEvent, getHighWaterMark, getDb } from '../db/index.js';
+import { validateEvent, checkSchemaAvailability, runSemanticChecks } from '../validate/engine.js';
+import { resolveAttribution } from '../attribution/resolve.js';
+import { fetchNip89Handlers } from '../attribution/nip89.js';
+import { loadFingerprints } from '../attribution/fingerprints.js';
+import { storeEvent, getHighWaterMark, getDb, createScanRun, finishScanRun } from '../db/index.js';
 import { parseDuration, formatNumber } from '../util.js';
 import type { RateLimitEvent } from '../types.js';
 
@@ -44,27 +46,14 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     ? opts.relays.split(',').map(r => r.trim()).filter(Boolean)
     : DEFAULT_RELAYS;
 
-  // Determine since timestamp.
-  // When no --since is given, use per-kind high-water marks so that each kind
-  // resumes from its own last-seen timestamp. This prevents a kind with recent
-  // activity from advancing the watermark past kinds that haven't been scanned.
+  // Determine since timestamp
   let since: number;
-  let perKindSince: Map<number, number> | null = null;
   if (opts.since) {
     const duration = parseDuration(opts.since);
     since = Math.floor(Date.now() / 1000) - duration;
   } else {
-    const fallback = Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
-    const kindTimestamps = new Map<number, number>();
-    let minSince = Infinity;
-    for (const kind of kinds) {
-      const hwm = getHighWaterMark(kind);
-      const ts = hwm ?? fallback;
-      kindTimestamps.set(kind, ts);
-      if (ts < minSince) minSince = ts;
-    }
-    since = minSince === Infinity ? fallback : minSince;
-    perKindSince = kindTimestamps;
+    const hwm = getHighWaterMark();
+    since = hwm ?? Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
   }
 
   // Apply time jitter: randomly look further back by up to 6 hours
@@ -94,8 +83,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     fetched: 0,
     duplicates: 0,
     newEvents: 0,
-    invalidEvents: 0,
-    violationErrors: 0,
+    violations: 0,
     rateLimits: 0,
   };
   const rateLimitEvents: RateLimitEvent[] = [];
@@ -103,13 +91,24 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   // Ensure DB is initialized
   getDb();
 
+  // Create scan run
+  const scanRunId = createScanRun(kinds, relays, since);
+  console.log(`  Scan run #${scanRunId}`);
+
+  // Load attribution data
+  console.log('  Loading attribution data...');
+  const nip89Map = await fetchNip89Handlers(relays);
+  console.log(`  NIP-89 handlers: ${nip89Map.size} pubkeys mapped`);
+  const fingerprints = loadFingerprints();
+  console.log(`  Fingerprints: ${fingerprints.length} app patterns loaded`);
+  console.log('');
+
   const startTime = Date.now();
 
   await fetchEvents({
     kinds,
     relays,
     since,
-    perKindSince: perKindSince ?? undefined,
     onRelayStart: (relay, index, total) => {
       console.log(`  [relay ${index + 1}/${total}] ${relay}`);
     },
@@ -128,16 +127,31 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
       progress.fetched++;
 
       const validation = validateEvent(event);
-      const client = extractClientTag(event.tags);
-      const isNew = storeEvent(event, validation, client, relay);
+      const semanticIssues = runSemanticChecks(event);
+
+      // Add semantic violations to validation errors for storage
+      for (const issue of semanticIssues) {
+        validation.errors.push({
+          instancePath: issue.path,
+          schemaPath: '',
+          keyword: issue.check_name,
+          params: {},
+          message: issue.message,
+        });
+        if (validation.valid !== false && issue.severity === 'error') {
+          validation.valid = false;
+        }
+      }
+
+      const attribution = resolveAttribution(event, nip89Map, fingerprints);
+      const isNew = storeEvent(event, validation, null, relay, scanRunId, attribution);
 
       if (!isNew) {
         progress.duplicates++;
       } else {
         progress.newEvents++;
         if (validation.valid === false) {
-          progress.invalidEvents++;
-          progress.violationErrors += validation.errors.length;
+          progress.violations += validation.errors.length;
         }
       }
 
@@ -150,16 +164,22 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     },
   });
 
+  // Finalize scan run
+  finishScanRun(scanRunId, {
+    events_fetched: progress.fetched,
+    events_new: progress.newEvents,
+    violations_found: progress.violations,
+  });
+
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log('');
-  console.log(`Finished in ${elapsed}s`);
+  console.log(`Finished in ${elapsed}s (scan run #${scanRunId})`);
   console.log('');
   console.log('Results:');
   console.log(`  Total fetched:  ${formatNumber(progress.fetched)}`);
   console.log(`  New events:     ${formatNumber(progress.newEvents)}`);
   console.log(`  Duplicates:     ${formatNumber(progress.duplicates)}`);
-  console.log(`  Invalid events: ${formatNumber(progress.invalidEvents)}`);
-  console.log(`  Violation errs: ${formatNumber(progress.violationErrors)}`);
+  console.log(`  Violations:     ${formatNumber(progress.violations)}`);
 
   if (progress.rateLimits > 0) {
     console.log('');

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -108,82 +108,84 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   const scanRunId = createScanRun(kinds, relays, since);
   console.log(`  Scan run #${scanRunId}`);
 
-  // Load attribution data
-  console.log('  Loading attribution data...');
-  const nip89Map = await fetchNip89Handlers(relays);
-  console.log(`  NIP-89 handlers: ${nip89Map.size} pubkeys mapped`);
-  const fingerprints = loadFingerprints();
-  console.log(`  Fingerprints: ${fingerprints.length} app patterns loaded`);
-  console.log('');
-
   const startTime = Date.now();
 
-  await fetchEvents({
-    kinds,
-    relays,
-    since,
-    perKindSince,
-    onRelayStart: (relay, index, total) => {
-      console.log(`  [relay ${index + 1}/${total}] ${relay}`);
-    },
-    onRelayDone: (relay, count) => {
-      console.log(`  [done] ${relay}: ${formatNumber(count)} events\n`);
-    },
-    onBatchStart: (_relay, batchKinds, batchIndex, totalBatches) => {
-      console.log(`    batch ${batchIndex + 1}/${totalBatches}: kinds [${batchKinds.join(', ')}]`);
-    },
-    onRateLimit: (event) => {
-      progress.rateLimits++;
-      rateLimitEvents.push(event);
-      console.error(`    !! RATE LIMITED by ${event.relay}: ${event.reason}`);
-    },
-    onEvent: (event, relay) => {
-      progress.fetched++;
+  try {
+    // Load attribution data
+    console.log('  Loading attribution data...');
+    const nip89Map = await fetchNip89Handlers(relays);
+    console.log(`  NIP-89 handlers: ${nip89Map.size} pubkeys mapped`);
+    const fingerprints = loadFingerprints();
+    console.log(`  Fingerprints: ${fingerprints.length} app patterns loaded`);
+    console.log('');
 
-      const validation = validateEvent(event);
-      const semanticIssues = runSemanticChecks(event);
+    await fetchEvents({
+      kinds,
+      relays,
+      since,
+      perKindSince,
+      onRelayStart: (relay, index, total) => {
+        console.log(`  [relay ${index + 1}/${total}] ${relay}`);
+      },
+      onRelayDone: (relay, count) => {
+        console.log(`  [done] ${relay}: ${formatNumber(count)} events\n`);
+      },
+      onBatchStart: (_relay, batchKinds, batchIndex, totalBatches) => {
+        console.log(`    batch ${batchIndex + 1}/${totalBatches}: kinds [${batchKinds.join(', ')}]`);
+      },
+      onRateLimit: (event) => {
+        progress.rateLimits++;
+        rateLimitEvents.push(event);
+        console.error(`    !! RATE LIMITED by ${event.relay}: ${event.reason}`);
+      },
+      onEvent: (event, relay) => {
+        progress.fetched++;
 
-      // Add semantic violations to validation errors for storage
-      for (const issue of semanticIssues) {
-        validation.errors.push({
-          instancePath: issue.path,
-          schemaPath: '',
-          keyword: issue.check_name,
-          params: { severity: issue.severity },
-          message: issue.message,
-        });
-        if (validation.valid !== false && issue.severity === 'error') {
-          validation.valid = false;
+        const validation = validateEvent(event);
+        const semanticIssues = runSemanticChecks(event);
+
+        // Add semantic violations to validation errors for storage
+        for (const issue of semanticIssues) {
+          validation.errors.push({
+            instancePath: issue.path,
+            schemaPath: '',
+            keyword: issue.check_name,
+            params: { severity: issue.severity },
+            message: issue.message,
+          });
+          if (validation.valid !== false && issue.severity === 'error') {
+            validation.valid = false;
+          }
         }
-      }
 
-      const attribution = resolveAttribution(event, nip89Map, fingerprints);
-      const isNew = storeEvent(event, validation, null, relay, scanRunId, attribution);
+        const attribution = resolveAttribution(event, nip89Map, fingerprints);
+        const isNew = storeEvent(event, validation, null, relay, scanRunId, attribution);
 
-      if (!isNew) {
-        progress.duplicates++;
-      } else {
-        progress.newEvents++;
-        if (validation.valid === false) {
-          progress.violations += validation.errors.length;
+        if (!isNew) {
+          progress.duplicates++;
+        } else {
+          progress.newEvents++;
+          if (validation.errors.length > 0) {
+            progress.violations += validation.errors.length;
+          }
         }
-      }
 
-      if (progress.fetched % 500 === 0) {
-        process.stdout.write(`\r    ${formatNumber(progress.fetched)} events processed...`);
-      }
-    },
-    onError: (error) => {
-      console.error(`\n  Warning: ${error}`);
-    },
-  });
-
-  // Finalize scan run
-  finishScanRun(scanRunId, {
-    events_fetched: progress.fetched,
-    events_new: progress.newEvents,
-    violations_found: progress.violations,
-  });
+        if (progress.fetched % 500 === 0) {
+          process.stdout.write(`\r    ${formatNumber(progress.fetched)} events processed...`);
+        }
+      },
+      onError: (error) => {
+        console.error(`\n  Warning: ${error}`);
+      },
+    });
+  } finally {
+    // Always finalize scan run, even on error
+    finishScanRun(scanRunId, {
+      events_fetched: progress.fetched,
+      events_new: progress.newEvents,
+      violations_found: progress.violations,
+    });
+  }
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log('');

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -46,14 +46,24 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     ? opts.relays.split(',').map(r => r.trim()).filter(Boolean)
     : DEFAULT_RELAYS;
 
-  // Determine since timestamp
+  // Determine since timestamp + per-kind watermarks
   let since: number;
+  let perKindSince: Map<number, number> | undefined;
   if (opts.since) {
     const duration = parseDuration(opts.since);
     since = Math.floor(Date.now() / 1000) - duration;
   } else {
-    const hwm = getHighWaterMark();
-    since = hwm ?? Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
+    // Use per-kind high water marks so frequent kinds don't starve rare ones
+    const fallback = Math.floor(Date.now() / 1000) - DEFAULT_SCAN_WINDOW_SECONDS;
+    perKindSince = new Map();
+    let minSince = Infinity;
+    for (const kind of kinds) {
+      const hwm = getHighWaterMark(kind);
+      const ts = hwm ?? fallback;
+      perKindSince.set(kind, ts);
+      if (ts < minSince) minSince = ts;
+    }
+    since = minSince === Infinity ? fallback : minSince;
   }
 
   // Apply time jitter: randomly look further back by up to 6 hours
@@ -77,6 +87,9 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   console.log(`  Kinds: ${kinds.join(', ')}`);
   console.log(`  Relays: ${relays.join(', ')} (order randomized)`);
   console.log(`  Since: ${sinceDate} (jitter: -${Math.floor(jitterApplied / 60)}m)`);
+  if (perKindSince) {
+    console.log(`  Using per-kind watermarks (${perKindSince.size} kinds)`);
+  }
   console.log('');
 
   const progress = {
@@ -109,6 +122,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     kinds,
     relays,
     since,
+    perKindSince,
     onRelayStart: (relay, index, total) => {
       console.log(`  [relay ${index + 1}/${total}] ${relay}`);
     },

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -135,7 +135,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
           instancePath: issue.path,
           schemaPath: '',
           keyword: issue.check_name,
-          params: {},
+          params: { severity: issue.severity },
           message: issue.message,
         });
         if (validation.valid !== false && issue.severity === 'error') {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -143,16 +143,17 @@ export function storeEvent(
 
     if (result.changes === 0) return false; // duplicate
 
-    if (validation.errors.length > 0 && validation.schemaKey) {
+    if (validation.errors.length > 0) {
       const stmt = getInsertViolation();
       for (const err of validation.errors) {
+        const sev = (err.params as Record<string, unknown>)?.severity;
         stmt.run({
           event_id: event.id,
-          schema_key: validation.schemaKey,
+          schema_key: validation.schemaKey ?? `kind${event.kind}Semantic`,
           error_path: err.instancePath || null,
           error_message: err.message || 'unknown error',
           error_keyword: err.keyword || null,
-          severity: 'error',
+          severity: typeof sev === 'string' ? sev : 'error',
         });
       }
     }
@@ -243,22 +244,23 @@ export function getRecentViolations(limit: number = 20): Array<{ event_id: strin
 
 // --- Export queries ---
 
-export function getAppKindMatrix(): Array<{ client_name: string; kind: number; total: number; valid: number; invalid: number }> {
+export function getAppKindMatrix(): Array<{ client_name: string; kind: number; total: number; valid: number; invalid: number; attribution_method: string | null }> {
   return getDb().prepare(`
     SELECT COALESCE(client_name, '_unattributed') as client_name, kind,
       COUNT(*) as total,
       SUM(CASE WHEN valid = 1 THEN 1 ELSE 0 END) as valid,
-      SUM(CASE WHEN valid = 0 THEN 1 ELSE 0 END) as invalid
+      SUM(CASE WHEN valid = 0 THEN 1 ELSE 0 END) as invalid,
+      MAX(attribution_method) as attribution_method
     FROM events
     GROUP BY 1, 2
     ORDER BY total DESC
-  `).all() as Array<{ client_name: string; kind: number; total: number; valid: number; invalid: number }>;
+  `).all() as Array<{ client_name: string; kind: number; total: number; valid: number; invalid: number; attribution_method: string | null }>;
 }
 
 export function getViolationDetails(): Array<{
   client_name: string; kind: number; error_keyword: string | null;
   error_path: string | null; error_message: string; count: number;
-  sample_event_ids: string | null;
+  sample_event_ids: string | null; severity: string;
 }> {
   return getDb().prepare(`
     SELECT base.*, (
@@ -274,15 +276,16 @@ export function getViolationDetails(): Array<{
     ) as sample_event_ids
     FROM (
       SELECT COALESCE(e.client_name, '_unattributed') as client_name, e.kind,
-        v.error_keyword, v.error_path, v.error_message, COUNT(*) as count
+        v.error_keyword, v.error_path, v.error_message, v.severity,
+        COUNT(*) as count
       FROM violations v JOIN events e ON e.id = v.event_id
-      GROUP BY 1, 2, 3, 4, 5
+      GROUP BY 1, 2, 3, 4, 5, 6
     ) base
     ORDER BY count DESC
   `).all() as Array<{
     client_name: string; kind: number; error_keyword: string | null;
     error_path: string | null; error_message: string; count: number;
-    sample_event_ids: string | null;
+    sample_event_ids: string | null; severity: string;
   }>;
 }
 
@@ -373,7 +376,7 @@ export function getSampleEvents(kind: number, clientName?: string, errorKeyword?
     query += ' AND v.error_keyword = ?';
     params.push(errorKeyword);
   }
-  query += ' ORDER BY e.created_at DESC LIMIT ?';
+  query += ' GROUP BY e.id ORDER BY e.created_at DESC LIMIT ?';
   params.push(limit);
 
   return getDb().prepare(query).all(...params) as Array<{
@@ -411,14 +414,23 @@ export function getTagFrequency(kind: number, clientName?: string): Array<{ tag_
     .slice(0, 30);
 }
 
-export function getPubkeyDistribution(): Array<{ client_name: string; kind: number; unique_pubkeys: number }> {
+export function getPubkeyCountByKind(): Array<{ kind: number; unique_pubkeys: number }> {
   return getDb().prepare(`
-    SELECT COALESCE(client_name, '_unattributed') as client_name, kind,
+    SELECT kind, COUNT(DISTINCT pubkey) as unique_pubkeys
+    FROM events
+    GROUP BY kind
+    ORDER BY unique_pubkeys DESC
+  `).all() as Array<{ kind: number; unique_pubkeys: number }>;
+}
+
+export function getPubkeyCountByApp(): Array<{ client_name: string; unique_pubkeys: number }> {
+  return getDb().prepare(`
+    SELECT COALESCE(client_name, '_unattributed') as client_name,
            COUNT(DISTINCT pubkey) as unique_pubkeys
     FROM events
-    GROUP BY 1, 2
+    GROUP BY 1
     ORDER BY unique_pubkeys DESC
-  `).all() as Array<{ client_name: string; kind: number; unique_pubkeys: number }>;
+  `).all() as Array<{ client_name: string; unique_pubkeys: number }>;
 }
 
 export function getAttributionSummary(): Array<{ method: string; count: number }> {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -61,8 +61,16 @@ function runMigrations(db: Database.Database): void {
     db.exec('ALTER TABLE events ADD COLUMN attribution_confidence TEXT');
   }
 
+  // Migrate violations table (for existing DBs created before severity column)
+  const violCols = db.prepare("PRAGMA table_info(violations)").all() as Array<{ name: string }>;
+  const violColNames = new Set(violCols.map(c => c.name));
+  if (!violColNames.has('severity')) {
+    db.exec("ALTER TABLE violations ADD COLUMN severity TEXT NOT NULL DEFAULT 'error'");
+  }
+
   // Create indexes on migrated columns (safe to run idempotently)
   db.exec('CREATE INDEX IF NOT EXISTS idx_events_scan_run ON events(scan_run_id)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_violations_severity ON violations(severity)');
 }
 
 let db: Database.Database | null = null;
@@ -271,6 +279,8 @@ export function getViolationDetails(): Array<{
           AND e2.kind = base.kind
           AND v2.error_keyword IS base.error_keyword
           AND v2.error_path IS base.error_path
+          AND v2.error_message = base.error_message
+          AND v2.severity IS base.severity
         LIMIT 3
       )
     ) as sample_event_ids

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { resolve } from 'node:path';
 import { DB_FILENAME } from '../config.js';
-import type { NostrEvent, ValidationResult, ClientAttribution } from '../types.js';
+import type { NostrEvent, ValidationResult, ClientAttribution, Attribution, ScanRun } from '../types.js';
 
 const SCHEMA_DDL = `
 CREATE TABLE IF NOT EXISTS events (
@@ -27,11 +27,43 @@ CREATE TABLE IF NOT EXISTS violations (
   severity      TEXT NOT NULL DEFAULT 'error'
 );
 
+CREATE TABLE IF NOT EXISTS scan_runs (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at     INTEGER NOT NULL DEFAULT (unixepoch()),
+  finished_at    INTEGER,
+  kinds          TEXT,
+  relays         TEXT,
+  since_ts       INTEGER,
+  events_fetched INTEGER DEFAULT 0,
+  events_new     INTEGER DEFAULT 0,
+  violations_found INTEGER DEFAULT 0,
+  ci_run_id      TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_events_kind ON events(kind);
 CREATE INDEX IF NOT EXISTS idx_events_valid ON events(valid);
 CREATE INDEX IF NOT EXISTS idx_events_client ON events(client_name);
 CREATE INDEX IF NOT EXISTS idx_violations_event ON violations(event_id);
 `;
+
+/** Idempotent migrations: add columns that may not exist yet */
+function runMigrations(db: Database.Database): void {
+  const eventCols = db.prepare("PRAGMA table_info(events)").all() as Array<{ name: string }>;
+  const colNames = new Set(eventCols.map(c => c.name));
+
+  if (!colNames.has('scan_run_id')) {
+    db.exec('ALTER TABLE events ADD COLUMN scan_run_id INTEGER REFERENCES scan_runs(id)');
+  }
+  if (!colNames.has('attribution_method')) {
+    db.exec('ALTER TABLE events ADD COLUMN attribution_method TEXT');
+  }
+  if (!colNames.has('attribution_confidence')) {
+    db.exec('ALTER TABLE events ADD COLUMN attribution_confidence TEXT');
+  }
+
+  // Create indexes on migrated columns (safe to run idempotently)
+  db.exec('CREATE INDEX IF NOT EXISTS idx_events_scan_run ON events(scan_run_id)');
+}
 
 let db: Database.Database | null = null;
 
@@ -42,6 +74,7 @@ export function getDb(): Database.Database {
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
   db.exec(SCHEMA_DDL);
+  runMigrations(db);
   return db;
 }
 
@@ -55,8 +88,8 @@ export function closeDb(): void {
 }
 
 const insertEventStmt = () => getDb().prepare(`
-  INSERT OR IGNORE INTO events (id, pubkey, kind, created_at, tags, raw, client_name, source_relay, valid)
-  VALUES (@id, @pubkey, @kind, @created_at, @tags, @raw, @client_name, @source_relay, @valid)
+  INSERT OR IGNORE INTO events (id, pubkey, kind, created_at, tags, raw, client_name, source_relay, valid, scan_run_id, attribution_method, attribution_confidence)
+  VALUES (@id, @pubkey, @kind, @created_at, @tags, @raw, @client_name, @source_relay, @valid, @scan_run_id, @attribution_method, @attribution_confidence)
 `);
 
 const insertViolationStmt = () => getDb().prepare(`
@@ -86,6 +119,8 @@ export function storeEvent(
   validation: ValidationResult,
   client: ClientAttribution | null,
   sourceRelay?: string,
+  scanRunId?: number,
+  attribution?: Attribution | null,
 ): boolean {
   const raw = JSON.stringify(event);
   const validValue = validation.valid === null ? null : validation.valid ? 1 : 0;
@@ -98,9 +133,12 @@ export function storeEvent(
       created_at: event.created_at,
       tags: JSON.stringify(event.tags),
       raw,
-      client_name: client?.name ?? null,
+      client_name: attribution?.name ?? client?.name ?? null,
       source_relay: sourceRelay ?? null,
       valid: validValue,
+      scan_run_id: scanRunId ?? null,
+      attribution_method: attribution?.method ?? (client ? 'client_tag' : null),
+      attribution_confidence: attribution?.confidence ?? (client ? 'high' : null),
     });
 
     if (result.changes === 0) return false; // duplicate
@@ -231,8 +269,6 @@ export function getViolationDetails(): Array<{
           AND e2.kind = base.kind
           AND v2.error_keyword IS base.error_keyword
           AND v2.error_path IS base.error_path
-          AND v2.error_message = base.error_message
-        ORDER BY e2.created_at DESC, e2.id
         LIMIT 3
       )
     ) as sample_event_ids
@@ -251,15 +287,15 @@ export function getViolationDetails(): Array<{
 }
 
 export function getTopPubkeysForErrors(): Array<{
-  error_keyword: string | null; error_path: string | null; error_message: string; pubkey: string; cnt: number;
+  error_keyword: string | null; error_path: string | null; pubkey: string; cnt: number;
 }> {
   return getDb().prepare(`
-    SELECT v.error_keyword, v.error_path, v.error_message, e.pubkey, COUNT(*) as cnt
+    SELECT v.error_keyword, v.error_path, e.pubkey, COUNT(*) as cnt
     FROM violations v JOIN events e ON e.id = v.event_id
-    GROUP BY 1, 2, 3, 4
-    ORDER BY 1, 2, 3, cnt DESC
+    GROUP BY 1, 2, 3
+    ORDER BY 1, 2, cnt DESC
   `).all() as Array<{
-    error_keyword: string | null; error_path: string | null; error_message: string; pubkey: string; cnt: number;
+    error_keyword: string | null; error_path: string | null; pubkey: string; cnt: number;
   }>;
 }
 
@@ -274,4 +310,175 @@ export function getDistinctRelays(): string[] {
     'SELECT DISTINCT source_relay FROM events WHERE source_relay IS NOT NULL ORDER BY source_relay'
   ).all() as Array<{ source_relay: string }>;
   return rows.map(r => r.source_relay);
+}
+
+// --- Scan run tracking ---
+
+export function createScanRun(kinds: number[], relays: string[], sinceTs: number): number {
+  const result = getDb().prepare(`
+    INSERT INTO scan_runs (kinds, relays, since_ts, ci_run_id)
+    VALUES (?, ?, ?, ?)
+  `).run(
+    JSON.stringify(kinds),
+    JSON.stringify(relays),
+    sinceTs,
+    process.env.GITHUB_RUN_ID ?? null,
+  );
+  return Number(result.lastInsertRowid);
+}
+
+export function finishScanRun(id: number, stats: { events_fetched: number; events_new: number; violations_found: number }): void {
+  getDb().prepare(`
+    UPDATE scan_runs
+    SET finished_at = unixepoch(),
+        events_fetched = ?,
+        events_new = ?,
+        violations_found = ?
+    WHERE id = ?
+  `).run(stats.events_fetched, stats.events_new, stats.violations_found, id);
+}
+
+export function getScanRunHistory(limit: number = 20): ScanRun[] {
+  return getDb().prepare(`
+    SELECT * FROM scan_runs ORDER BY started_at DESC LIMIT ?
+  `).all(limit) as ScanRun[];
+}
+
+// --- Phase 3: Drill-down queries ---
+
+export function getSampleEvents(kind: number, clientName?: string, errorKeyword?: string, limit: number = 3): Array<{
+  id: string; pubkey: string; kind: number; created_at: number; raw: string; client_name: string | null;
+  attribution_method: string | null; attribution_confidence: string | null;
+}> {
+  let query = `
+    SELECT e.id, e.pubkey, e.kind, e.created_at, e.raw, e.client_name,
+           e.attribution_method, e.attribution_confidence
+    FROM events e
+  `;
+  const params: unknown[] = [];
+
+  if (errorKeyword) {
+    query += ' JOIN violations v ON v.event_id = e.id';
+  }
+  query += ' WHERE e.kind = ?';
+  params.push(kind);
+
+  if (clientName === '_unattributed') {
+    query += ' AND e.client_name IS NULL';
+  } else if (clientName) {
+    query += ' AND e.client_name = ?';
+    params.push(clientName);
+  }
+  if (errorKeyword) {
+    query += ' AND v.error_keyword = ?';
+    params.push(errorKeyword);
+  }
+  query += ' ORDER BY e.created_at DESC LIMIT ?';
+  params.push(limit);
+
+  return getDb().prepare(query).all(...params) as Array<{
+    id: string; pubkey: string; kind: number; created_at: number; raw: string; client_name: string | null;
+    attribution_method: string | null; attribution_confidence: string | null;
+  }>;
+}
+
+export function getTagFrequency(kind: number, clientName?: string): Array<{ tag_name: string; count: number }> {
+  // Parse tags in JS since SQLite JSON can be tricky with nested arrays
+  const params: unknown[] = [kind];
+  if (clientName && clientName !== '_unattributed') params.push(clientName);
+
+  const rows = getDb().prepare(`
+    SELECT e.tags FROM events e WHERE e.kind = ?
+    ${clientName === '_unattributed' ? 'AND e.client_name IS NULL' : clientName ? 'AND e.client_name = ?' : ''}
+    LIMIT 1000
+  `).all(...params) as Array<{ tags: string }>;
+
+  const freqMap = new Map<string, number>();
+  for (const row of rows) {
+    try {
+      const tags = JSON.parse(row.tags) as string[][];
+      for (const tag of tags) {
+        if (tag[0]) {
+          freqMap.set(tag[0], (freqMap.get(tag[0]) ?? 0) + 1);
+        }
+      }
+    } catch { /* skip malformed */ }
+  }
+
+  return [...freqMap.entries()]
+    .map(([tag_name, count]) => ({ tag_name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 30);
+}
+
+export function getPubkeyDistribution(): Array<{ client_name: string; kind: number; unique_pubkeys: number }> {
+  return getDb().prepare(`
+    SELECT COALESCE(client_name, '_unattributed') as client_name, kind,
+           COUNT(DISTINCT pubkey) as unique_pubkeys
+    FROM events
+    GROUP BY 1, 2
+    ORDER BY unique_pubkeys DESC
+  `).all() as Array<{ client_name: string; kind: number; unique_pubkeys: number }>;
+}
+
+export function getAttributionSummary(): Array<{ method: string; count: number }> {
+  return getDb().prepare(`
+    SELECT COALESCE(attribution_method, 'unattributed') as method, COUNT(*) as count
+    FROM events
+    GROUP BY 1
+    ORDER BY count DESC
+  `).all() as Array<{ method: string; count: number }>;
+}
+
+// --- Phase 4: Trend queries ---
+
+export function getAppTrend(clientName: string, groupBy: 'day' | 'week' = 'day'): Array<{
+  period: string; total: number; invalid: number; error_rate: number;
+}> {
+  const dateFmt = groupBy === 'week' ? '%Y-W%W' : '%Y-%m-%d';
+  const client = clientName === '_unattributed' ? null : clientName;
+
+  return getDb().prepare(`
+    SELECT strftime('${dateFmt}', e.created_at, 'unixepoch') as period,
+           COUNT(*) as total,
+           SUM(CASE WHEN e.valid = 0 THEN 1 ELSE 0 END) as invalid,
+           CASE WHEN SUM(CASE WHEN e.valid IS NOT NULL THEN 1 ELSE 0 END) > 0
+             THEN ROUND(CAST(SUM(CASE WHEN e.valid = 0 THEN 1 ELSE 0 END) AS REAL)
+               / SUM(CASE WHEN e.valid IS NOT NULL THEN 1 ELSE 0 END), 4)
+             ELSE 0
+           END as error_rate
+    FROM events e
+    WHERE ${client === null ? 'e.client_name IS NULL' : 'e.client_name = ?'}
+    GROUP BY period
+    ORDER BY period
+  `).all(...(client === null ? [] : [client])) as Array<{
+    period: string; total: number; invalid: number; error_rate: number;
+  }>;
+}
+
+export function getAllAppTrends(lastNDays: number = 30): Array<{
+  client_name: string; total: number; invalid: number; error_rate: number;
+  first_seen: string; last_seen: string; data_points: number;
+}> {
+  const cutoff = Math.floor(Date.now() / 1000) - lastNDays * 86400;
+  return getDb().prepare(`
+    SELECT COALESCE(e.client_name, '_unattributed') as client_name,
+           COUNT(*) as total,
+           SUM(CASE WHEN e.valid = 0 THEN 1 ELSE 0 END) as invalid,
+           CASE WHEN SUM(CASE WHEN e.valid IS NOT NULL THEN 1 ELSE 0 END) > 0
+             THEN ROUND(CAST(SUM(CASE WHEN e.valid = 0 THEN 1 ELSE 0 END) AS REAL)
+               / SUM(CASE WHEN e.valid IS NOT NULL THEN 1 ELSE 0 END), 4)
+             ELSE 0
+           END as error_rate,
+           strftime('%Y-%m-%d', MIN(e.created_at), 'unixepoch') as first_seen,
+           strftime('%Y-%m-%d', MAX(e.created_at), 'unixepoch') as last_seen,
+           COUNT(DISTINCT strftime('%Y-%m-%d', e.created_at, 'unixepoch')) as data_points
+    FROM events e
+    WHERE e.created_at >= ?
+    GROUP BY 1
+    ORDER BY total DESC
+  `).all(cutoff) as Array<{
+    client_name: string; total: number; invalid: number; error_rate: number;
+    first_seen: string; last_seen: string; data_points: number;
+  }>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ program
 program
   .command('report')
   .description('Show violation reports')
-  .option('--by <grouping>', 'Group by: kind, client, error, recent (default: kind)')
+  .option('--by <grouping>', 'Group by: kind, client, error, recent, trend (default: kind)')
   .option('--format <format>', 'Output format: table, json, csv (default: table)')
   .option('--limit <n>', 'Limit number of results')
   .action((opts) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,3 +62,37 @@ export interface RateLimitEvent {
   relay: string;
   reason: string;
 }
+
+export interface ScanRun {
+  id: number;
+  started_at: number;
+  finished_at: number | null;
+  kinds: string | null;       // JSON array
+  relays: string | null;      // JSON array
+  since_ts: number | null;
+  events_fetched: number;
+  events_new: number;
+  violations_found: number;
+  ci_run_id: string | null;
+}
+
+export interface Attribution {
+  name: string;
+  method: 'client_tag' | 'nip89_pubkey' | 'fingerprint';
+  confidence: 'high' | 'medium' | 'low';
+  address?: string;
+}
+
+export interface AppFingerprint {
+  app_name: string;
+  pubkey_prefix?: string[];
+  tag_pattern?: { tag: string; value?: string }[];
+  content_pattern?: string[];
+}
+
+export interface SemanticViolation {
+  check_name: string;
+  message: string;
+  path: string;
+  severity: 'warning' | 'error';
+}

--- a/src/validate/checks/kind0.ts
+++ b/src/validate/checks/kind0.ts
@@ -2,7 +2,7 @@ import type { SemanticCheck } from '../semantic.js';
 import type { NostrEvent, SemanticViolation } from '../../types.js';
 
 const URL_PATTERN = /^https?:\/\/.+/;
-const NIP05_PATTERN = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const NIP05_PATTERN = /^[a-zA-Z0-9._-]+@([a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
 
 export const kind0Checks: SemanticCheck[] = [
   {

--- a/src/validate/checks/kind0.ts
+++ b/src/validate/checks/kind0.ts
@@ -1,0 +1,66 @@
+import type { SemanticCheck } from '../semantic.js';
+import type { NostrEvent, SemanticViolation } from '../../types.js';
+
+const URL_PATTERN = /^https?:\/\/.+/;
+const NIP05_PATTERN = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+export const kind0Checks: SemanticCheck[] = [
+  {
+    kind: 0,
+    name: 'kind0_picture_url',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      try {
+        const profile = JSON.parse(event.content);
+        const violations: SemanticViolation[] = [];
+
+        if (profile.picture && typeof profile.picture === 'string' && profile.picture.length > 0) {
+          if (!URL_PATTERN.test(profile.picture)) {
+            violations.push({
+              check_name: 'kind0_picture_url',
+              message: `picture field is not a valid URL: "${profile.picture.slice(0, 50)}"`,
+              path: '/content/picture',
+              severity: 'warning',
+            });
+          }
+        }
+
+        if (profile.banner && typeof profile.banner === 'string' && profile.banner.length > 0) {
+          if (!URL_PATTERN.test(profile.banner)) {
+            violations.push({
+              check_name: 'kind0_banner_url',
+              message: `banner field is not a valid URL: "${profile.banner.slice(0, 50)}"`,
+              path: '/content/banner',
+              severity: 'warning',
+            });
+          }
+        }
+
+        return violations;
+      } catch {
+        return []; // Content not valid JSON — already caught by schema validation
+      }
+    },
+  },
+  {
+    kind: 0,
+    name: 'kind0_nip05_format',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      try {
+        const profile = JSON.parse(event.content);
+        if (profile.nip05 && typeof profile.nip05 === 'string' && profile.nip05.length > 0) {
+          if (!NIP05_PATTERN.test(profile.nip05)) {
+            return [{
+              check_name: 'kind0_nip05_format',
+              message: `nip05 field has invalid format: "${profile.nip05.slice(0, 50)}"`,
+              path: '/content/nip05',
+              severity: 'warning',
+            }];
+          }
+        }
+        return [];
+      } catch {
+        return [];
+      }
+    },
+  },
+];

--- a/src/validate/checks/kind10002.ts
+++ b/src/validate/checks/kind10002.ts
@@ -1,0 +1,49 @@
+import type { SemanticCheck } from '../semantic.js';
+import type { NostrEvent, SemanticViolation } from '../../types.js';
+
+const WSS_PATTERN = /^wss?:\/\/.+/;
+
+export const kind10002Checks: SemanticCheck[] = [
+  {
+    kind: 10002,
+    name: 'kind10002_relay_url_format',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      const violations: SemanticViolation[] = [];
+      const rTags = event.tags.filter(t => t[0] === 'r' && t[1]);
+
+      for (const tag of rTags) {
+        const url = tag[1];
+        if (!WSS_PATTERN.test(url)) {
+          violations.push({
+            check_name: 'kind10002_relay_url_format',
+            message: `Relay URL does not use wss:// scheme: "${url.slice(0, 60)}"`,
+            path: '/tags',
+            severity: 'warning',
+          });
+        }
+      }
+
+      return violations;
+    },
+  },
+  {
+    kind: 10002,
+    name: 'kind10002_duplicate_relays',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      const rTags = event.tags.filter(t => t[0] === 'r' && t[1]);
+      const urls = rTags.map(t => t[1].toLowerCase().replace(/\/+$/, ''));
+      const unique = new Set(urls);
+
+      if (unique.size < urls.length) {
+        const dupeCount = urls.length - unique.size;
+        return [{
+          check_name: 'kind10002_duplicate_relays',
+          message: `Relay list has ${dupeCount} duplicate relay URL(s)`,
+          path: '/tags',
+          severity: 'warning',
+        }];
+      }
+      return [];
+    },
+  },
+];

--- a/src/validate/checks/kind10002.ts
+++ b/src/validate/checks/kind10002.ts
@@ -1,7 +1,7 @@
 import type { SemanticCheck } from '../semantic.js';
 import type { NostrEvent, SemanticViolation } from '../../types.js';
 
-const WSS_PATTERN = /^wss?:\/\/.+/;
+const WSS_PATTERN = /^wss:\/\/.+/;
 
 export const kind10002Checks: SemanticCheck[] = [
   {

--- a/src/validate/checks/kind3.ts
+++ b/src/validate/checks/kind3.ts
@@ -1,0 +1,41 @@
+import type { SemanticCheck } from '../semantic.js';
+import type { NostrEvent, SemanticViolation } from '../../types.js';
+
+export const kind3Checks: SemanticCheck[] = [
+  {
+    kind: 3,
+    name: 'kind3_duplicate_pubkeys',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      const pTags = event.tags.filter(t => t[0] === 'p' && t[1]);
+      const pubkeys = pTags.map(t => t[1]);
+      const unique = new Set(pubkeys);
+
+      if (unique.size < pubkeys.length) {
+        const dupeCount = pubkeys.length - unique.size;
+        return [{
+          check_name: 'kind3_duplicate_pubkeys',
+          message: `Contact list has ${dupeCount} duplicate p tag(s) (${pubkeys.length} total, ${unique.size} unique)`,
+          path: '/tags',
+          severity: 'warning',
+        }];
+      }
+      return [];
+    },
+  },
+  {
+    kind: 3,
+    name: 'kind3_self_reference',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      const selfRef = event.tags.find(t => t[0] === 'p' && t[1] === event.pubkey);
+      if (selfRef) {
+        return [{
+          check_name: 'kind3_self_reference',
+          message: 'Contact list contains a p tag referencing the event author',
+          path: '/tags',
+          severity: 'warning',
+        }];
+      }
+      return [];
+    },
+  },
+];

--- a/src/validate/checks/kind9735.ts
+++ b/src/validate/checks/kind9735.ts
@@ -1,0 +1,63 @@
+import type { SemanticCheck } from '../semantic.js';
+import type { NostrEvent, SemanticViolation } from '../../types.js';
+
+/**
+ * Parse millisat amount from a bolt11 invoice prefix.
+ * Only handles the amount prefix (before the 1-separator), no full decode.
+ * Returns null if unparseable.
+ */
+function parseBolt11Amount(bolt11: string): number | null {
+  const lower = bolt11.toLowerCase();
+  // bolt11 format: ln[tb][c]<amount><multiplier>1<data...>
+  const match = lower.match(/^ln(?:bc|tb|tbs|bcrt)(\d+)([munp]?)1/);
+  if (!match) return null;
+
+  const base = parseInt(match[1], 10);
+  if (isNaN(base)) return null;
+
+  const multiplier = match[2];
+  // Convert to millisats
+  // Base unit is BTC, so 1 = 100_000_000_000 msat
+  switch (multiplier) {
+    case 'm': return base * 100_000_000;   // milli-BTC
+    case 'u': return base * 100_000;       // micro-BTC
+    case 'n': return base * 100;           // nano-BTC
+    case 'p': return base / 10;            // pico-BTC (0.1 msat)
+    case '':  return base * 100_000_000_000; // BTC
+    default: return null;
+  }
+}
+
+export const kind9735Checks: SemanticCheck[] = [
+  {
+    kind: 9735,
+    name: 'kind9735_bolt11_amount_mismatch',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      // Find bolt11 tag
+      const bolt11Tag = event.tags.find(t => t[0] === 'bolt11' && t[1]);
+      if (!bolt11Tag) return [];
+
+      // Find amount tag (in millisats)
+      const amountTag = event.tags.find(t => t[0] === 'amount' && t[1]);
+      if (!amountTag) return [];
+
+      const tagAmount = parseInt(amountTag[1], 10);
+      if (isNaN(tagAmount)) return [];
+
+      const bolt11Amount = parseBolt11Amount(bolt11Tag[1]);
+      if (bolt11Amount === null) return []; // Can't parse, skip
+
+      // Compare (allow 1% tolerance for rounding)
+      if (Math.abs(bolt11Amount - tagAmount) > Math.max(tagAmount * 0.01, 1)) {
+        return [{
+          check_name: 'kind9735_bolt11_amount_mismatch',
+          message: `bolt11 amount (${bolt11Amount} msat) does not match amount tag (${tagAmount} msat)`,
+          path: '/tags',
+          severity: 'warning',
+        }];
+      }
+
+      return [];
+    },
+  },
+];

--- a/src/validate/checks/universal.ts
+++ b/src/validate/checks/universal.ts
@@ -1,0 +1,39 @@
+import type { SemanticCheck } from '../semantic.js';
+import type { NostrEvent, SemanticViolation } from '../../types.js';
+
+const FIFTEEN_MINUTES = 15 * 60;
+const NOSTR_EPOCH = 1577836800; // 2020-01-01 00:00:00 UTC
+
+export const universalChecks: SemanticCheck[] = [
+  {
+    kind: '*',
+    name: 'future_timestamp',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      const now = Math.floor(Date.now() / 1000);
+      if (event.created_at > now + FIFTEEN_MINUTES) {
+        return [{
+          check_name: 'future_timestamp',
+          message: `Timestamp is ${Math.floor((event.created_at - now) / 60)} minutes in the future`,
+          path: '/created_at',
+          severity: 'warning',
+        }];
+      }
+      return [];
+    },
+  },
+  {
+    kind: '*',
+    name: 'timestamp_too_old',
+    check: (event: NostrEvent): SemanticViolation[] => {
+      if (event.created_at < NOSTR_EPOCH) {
+        return [{
+          check_name: 'timestamp_too_old',
+          message: `Timestamp is before 2020-01-01 (${new Date(event.created_at * 1000).toISOString()})`,
+          path: '/created_at',
+          severity: 'warning',
+        }];
+      }
+      return [];
+    },
+  },
+];

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -13,9 +13,9 @@ function loadSchemas(): Record<string, unknown> {
   // Walk the dist/nips directory to find kind schemas directly
   // (the ESM bundle re-exports don't work with require())
   const schemataDir = require.resolve('@nostrability/schemata/package.json');
-  const pkgDir = schemataDir.replace('/package.json', '');
   const fs = require('fs');
   const path = require('path');
+  const pkgDir = path.dirname(schemataDir);
 
   schemas = {};
   const nipsDir = path.join(pkgDir, 'dist', 'nips');

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import Ajv, { type ValidateFunction } from 'ajv';
-import type { NostrEvent, ValidationResult } from '../types.js';
+import type { NostrEvent, ValidationResult, SemanticViolation } from '../types.js';
+import { runAllSemanticChecks } from './semantic.js';
 
 const require = createRequire(import.meta.url);
 
@@ -12,9 +13,9 @@ function loadSchemas(): Record<string, unknown> {
   // Walk the dist/nips directory to find kind schemas directly
   // (the ESM bundle re-exports don't work with require())
   const schemataDir = require.resolve('@nostrability/schemata/package.json');
-  const path = require('path');
-  const pkgDir = path.dirname(schemataDir);
+  const pkgDir = schemataDir.replace('/package.json', '');
   const fs = require('fs');
+  const path = require('path');
 
   schemas = {};
   const nipsDir = path.join(pkgDir, 'dist', 'nips');
@@ -36,11 +37,7 @@ function loadSchemas(): Record<string, unknown> {
         const schemaPath = path.join(nipPath, entry, 'schema.json');
         if (fs.existsSync(schemaPath)) {
           const key = `kind${kindNum}Schema`;
-          try {
-            schemas[key] = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-          } catch (err) {
-            console.error(`Warning: Failed to parse ${schemaPath}:`, err);
-          }
+          schemas[key] = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
         }
       }
     }
@@ -121,23 +118,27 @@ function stripErrorMessages(obj: unknown): void {
 
 /**
  * Check that schemata package is importable and has schemas for our target kinds.
- * Also verifies schemas can be compiled by AJV (triggers lazy compilation + caching).
  * Returns list of available kind schema keys.
  */
 export function checkSchemaAvailability(kinds: number[]): { available: string[]; missing: string[] } {
+  const allSchemas = loadSchemas();
   const available: string[] = [];
   const missing: string[] = [];
   for (const kind of kinds) {
     const key = `kind${kind}Schema`;
-    // Trigger validateEvent to force schema compilation and caching.
-    // A dummy event is used — we only care whether a validator was produced.
-    const dummyEvent: NostrEvent = { id: '', pubkey: '', kind, created_at: 0, tags: [], content: '', sig: '' };
-    const result = validateEvent(dummyEvent);
-    if (result.schemaKey) {
+    if (allSchemas[key]) {
       available.push(key);
     } else {
       missing.push(key);
     }
   }
   return { available, missing };
+}
+
+/**
+ * Run semantic validation checks on an event.
+ * These go beyond JSON Schema to catch logical issues.
+ */
+export function runSemanticChecks(event: NostrEvent): SemanticViolation[] {
+  return runAllSemanticChecks(event);
 }

--- a/src/validate/semantic.ts
+++ b/src/validate/semantic.ts
@@ -1,0 +1,41 @@
+import type { NostrEvent, SemanticViolation } from '../types.js';
+import { universalChecks } from './checks/universal.js';
+import { kind0Checks } from './checks/kind0.js';
+import { kind3Checks } from './checks/kind3.js';
+import { kind10002Checks } from './checks/kind10002.js';
+import { kind9735Checks } from './checks/kind9735.js';
+
+export interface SemanticCheck {
+  kind: number | '*';
+  name: string;
+  check: (event: NostrEvent) => SemanticViolation[];
+}
+
+const registry: SemanticCheck[] = [
+  ...universalChecks,
+  ...kind0Checks,
+  ...kind3Checks,
+  ...kind10002Checks,
+  ...kind9735Checks,
+];
+
+/**
+ * Run all applicable semantic checks on an event.
+ * Returns violations found (may be empty).
+ */
+export function runAllSemanticChecks(event: NostrEvent): SemanticViolation[] {
+  const violations: SemanticViolation[] = [];
+
+  for (const check of registry) {
+    if (check.kind !== '*' && check.kind !== event.kind) continue;
+
+    try {
+      const results = check.check(event);
+      violations.push(...results);
+    } catch {
+      // Don't let a buggy check break the pipeline
+    }
+  }
+
+  return violations;
+}


### PR DESCRIPTION
## Summary

Sherlock v2 adds the ability to identify which app is responsible for protocol violations and track whether apps are improving over time.

**Problem:** ~95% of events are `_unattributed` (no NIP-89 client tag). When violations are found, we can't tell which app is broken. Each scan adds to a flat pool with no time dimension.

**Solution — 5 phases in 5 commits:**

### 1. Scan history tracking (`src/db`, `src/types`)
- `scan_runs` table tracks each invocation with kinds, relays, since, event counts, CI run ID
- `scan_run_id` column on events links to the run that found them
- Idempotent `ALTER TABLE` migrations (nullable columns, `PRAGMA table_info` check)

### 2. Enhanced attribution (`src/attribution/`)
- Three-tier resolution cascade: client_tag (high) → NIP-89 pubkey map (medium) → fingerprint (low)
- `nip89.ts`: fetches kind:31990 handlers from relays (sequential, relay-friendly pauses)
- `fingerprints.ts`: loads `data/app-fingerprints.json` for pubkey prefix, tag pattern, content pattern matching
- Seed data for 7 known Nostr apps

### 3. Semantic validation (`src/validate/checks/`, `src/validate/semantic.ts`)
- Plugin registry with kind-based dispatch
- 5 check modules: universal (timestamps), kind0 (URLs, nip05), kind3 (duplicate contacts, self-ref), kind10002 (relay URLs, dupes), kind9735 (bolt11 amount mismatch)
- Violations stored with `severity: 'warning'` to distinguish from schema errors

### 4. Scan command integration (`src/commands/scan.ts`)
- Creates/finalizes scan runs with counts
- Fetches NIP-89 handlers and fingerprints once per scan
- Replaces `extractClientTag()` with `resolveAttribution()` cascade
- Runs semantic checks alongside schema validation

### 5. Dashboard, trends, and drill-down (`src/commands/export.ts`, `report.ts`)
- **Findings v2**: `attribution_summary`, `unique_pubkeys`, `is_widespread`, `semantic_warnings`, `trends.by_app`
- **New Trends tab**: CSS sparkline bars, direction arrows (improving/worsening/stable)
- **Attribution badges**: tag/nip89/fp method indicators next to app names
- **Pubkey count badges**: distinguish widespread client bugs from individual misconfiguration
- **Semantic warning rows**: yellow badges vs red for schema errors
- **`report --by trend`**: CLI trend report for last 30 days
- Direction heuristic: compare avg error rate of last 3 vs previous 3 data points

### Stats
- **17 files changed**, 1,225 insertions, 156 deletions
- **8 new files**, 9 modified
- Zero new dependencies

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npx tsc --noEmit` — no type errors
- [x] `node dist/index.js stats` — shows data with migrated schema
- [x] `node dist/index.js export` — generates findings.json + dashboard
- [x] `node dist/index.js report --by trend` — shows trend data
- [x] `sqlite3 sherlock.db ".schema"` — verifies scan_runs table and new columns
- [ ] `node dist/index.js scan --since 1h --kinds 0,3` — live scan with attribution
- [ ] `open docs/index.html` — verify Trends tab and attribution badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App attribution across client tags, NIP-89 handlers, and shipped fingerprint dataset (includes Damus, Primal, Amethyst, Snort, Coracle, Nostrudel, Gossip).
  * Semantic validation added for multiple event kinds and a registry to run these checks.
  * Scan run tracking and trend reporting with a new Trends panel and attribution/trend badges in the HTML dashboard.
  * CLI report supports grouping by trend.

* **Chores**
  * Database schema extended for attribution, scan runs, and trend analytics.
  * Added types and a bundled fingerprint data file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->