### PR TITLE
feat(scan): expand to all schemata kinds with --all-schemas

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -18,7 +18,7 @@ import {
   getAppTrend,
   getAllAppTrends,
 } from '../db/index.js';
-import { KIND_NAMES, STATUS_THRESHOLDS, GITHUB_REPO, DEFAULT_KINDS } from '../config.js';
+import { getKindNames, STATUS_THRESHOLDS, GITHUB_REPO } from '../config.js';
 import { which } from '../util.js';
 
 // --- Types ---
@@ -121,6 +121,7 @@ function computeTrendDirection(dataPoints: TrendDataPoint[]): AppTrend['directio
 
 function buildFindings(): Findings {
   getDb(); // ensure initialized
+  const kindNames = getKindNames();
 
   const total = getTotalEvents();
   const byKind = getEventCountsByKind();
@@ -211,7 +212,7 @@ function buildFindings(): Findings {
     const kindPubkeys = kindPubkeyMap.get(r.kind) ?? 0;
 
     findingsByKind[String(r.kind)] = {
-      name: KIND_NAMES[r.kind] ?? `Kind ${r.kind}`,
+      name: kindNames[r.kind] ?? `Kind ${r.kind}`,
       schema_key: `kind${r.kind}Schema`,
       total: r.total, valid: r.valid, invalid: r.invalid,
       error_rate: Math.round(errorRate * 10000) / 10000,
@@ -429,7 +430,7 @@ tr.detail td { padding-left: 32px; background: var(--hover); }
 <script>
 var FINDINGS = ${data};
 
-var KIND_NAMES = ${JSON.stringify(KIND_NAMES)};
+var KIND_NAMES = ${JSON.stringify(getKindNames())};
 
 function esc(s) { if (s == null) return ''; var d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
 function pct(n, t) { return t > 0 ? (n/t*100).toFixed(1) + '%' : '0.0%'; }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_RELAYS, DEFAULT_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE } from '../config.js';
+import { DEFAULT_RELAYS, PRIORITY_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE } from '../config.js';
 import { fetchEvents, checkNak } from '../fetch/nak.js';
-import { validateEvent, checkSchemaAvailability, runSemanticChecks } from '../validate/engine.js';
+import { validateEvent, checkSchemaAvailability, runSemanticChecks, getAvailableKinds } from '../validate/engine.js';
 import { resolveAttribution } from '../attribution/resolve.js';
 import { fetchNip89Handlers } from '../attribution/nip89.js';
 import { loadFingerprints } from '../attribution/fingerprints.js';
@@ -10,6 +10,7 @@ import type { RateLimitEvent } from '../types.js';
 
 interface ScanCommandOptions {
   kinds?: string;
+  allSchemas?: boolean;
   relays?: string;
   since?: string;
   jitter?: string;
@@ -36,10 +37,16 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   }
   console.log(`Using nak: ${nakPath}`);
 
-  // Parse kinds
-  const kinds = opts.kinds
-    ? opts.kinds.split(',').map(k => parseInt(k.trim(), 10)).filter(k => !isNaN(k))
-    : DEFAULT_KINDS;
+  // Resolve kinds: --kinds CSV > --all-schemas > default priority kinds
+  const allAvailable = getAvailableKinds();
+  let kinds: number[];
+  if (opts.kinds) {
+    kinds = opts.kinds.split(',').map(k => parseInt(k.trim(), 10)).filter(k => !isNaN(k));
+  } else if (opts.allSchemas) {
+    kinds = allAvailable;
+  } else {
+    kinds = PRIORITY_KINDS;
+  }
 
   // Parse relays
   const relays = opts.relays
@@ -75,7 +82,8 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
 
   // Check schema availability
   const { available, missing } = checkSchemaAvailability(kinds);
-  console.log(`\nSchema coverage: ${available.length}/${kinds.length} kinds`);
+  console.log(`\nAvailable schemas: ${allAvailable.length} | Scanning: ${kinds.length} kinds`);
+  console.log(`  Schema coverage: ${available.length}/${kinds.length} kinds`);
   if (missing.length > 0) {
     console.log(`  Missing schemas: ${missing.join(', ')}`);
     console.log(`  Events for these kinds will be stored with valid=NULL`);
@@ -83,7 +91,8 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
 
   const sinceDate = new Date(since * 1000).toISOString();
   const numBatches = Math.ceil(kinds.length / DEFAULT_KIND_BATCH_SIZE);
-  console.log(`\nScanning ${kinds.length} kinds in ${numBatches} batches from ${relays.length} relays`);
+  const estMinutes = Math.ceil(numBatches * relays.length * 7 / 60); // ~7s per batch (5s paginate + 2s pause)
+  console.log(`\nScanning ${kinds.length} kinds in ${numBatches} batches from ${relays.length} relays (~${estMinutes}min)`);
   console.log(`  Kinds: ${kinds.join(', ')}`);
   console.log(`  Relays: ${relays.join(', ')} (order randomized)`);
   console.log(`  Since: ${sinceDate} (jitter: -${Math.floor(jitterApplied / 60)}m)`);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_RELAYS, PRIORITY_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE } from '../config.js';
+import { DEFAULT_RELAYS, PRIORITY_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE, DEFAULT_RELAY_PAUSE_MS } from '../config.js';
 import { fetchEvents, checkNak } from '../fetch/nak.js';
 import { validateEvent, checkSchemaAvailability, runSemanticChecks, getAvailableKinds } from '../validate/engine.js';
 import { resolveAttribution } from '../attribution/resolve.js';
@@ -91,7 +91,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
 
   const sinceDate = new Date(since * 1000).toISOString();
   const numBatches = Math.ceil(kinds.length / DEFAULT_KIND_BATCH_SIZE);
-  const estMinutes = Math.ceil(numBatches * relays.length * 7 / 60); // ~7s per batch (5s paginate + 2s pause)
+  const estMinutes = Math.ceil((numBatches * 7 + DEFAULT_RELAY_PAUSE_MS / 1000) * relays.length / 60);
   console.log(`\nScanning ${kinds.length} kinds in ${numBatches} batches from ${relays.length} relays (~${estMinutes}min)`);
   console.log(`  Kinds: ${kinds.join(', ')}`);
   console.log(`  Relays: ${relays.join(', ')} (order randomized)`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { getKindNipMap } from './validate/engine.js';
+
 export const DEFAULT_RELAYS = [
   'wss://relay.damus.io',
   'wss://nos.lol',
@@ -6,7 +8,7 @@ export const DEFAULT_RELAYS = [
 
 export const PUBLISH_RELAYS = DEFAULT_RELAYS;
 
-export const DEFAULT_KINDS = [
+export const PRIORITY_KINDS = [
   0,      // NIP-01: Profile metadata
   3,      // NIP-02: Contact list
   10002,  // NIP-65: Relay list metadata
@@ -38,7 +40,7 @@ export const DB_FILENAME = 'sherlock.db';
 
 export const GITHUB_REPO = 'https://github.com/nostrability/sherlock';
 
-export const KIND_NAMES: Record<number, string> = {
+export const PRIORITY_KIND_NAMES: Record<number, string> = {
   0:     'Profile Metadata (NIP-01)',
   3:     'Contact List (NIP-02)',
   10002: 'Relay List Metadata (NIP-65)',
@@ -56,6 +58,25 @@ export const KIND_NAMES: Record<number, string> = {
   9734:  'Zap Request (NIP-57)',
   9735:  'Zap Receipt (NIP-57)',
 };
+
+let _kindNamesCache: Record<number, string> | null = null;
+
+/**
+ * Get human-readable names for all known kinds.
+ * Priority kinds use hand-written names; others use "Kind N (NIP-XX)" from schemata.
+ */
+export function getKindNames(): Record<number, string> {
+  if (_kindNamesCache) return _kindNamesCache;
+  const names: Record<number, string> = { ...PRIORITY_KIND_NAMES };
+  const nipMap = getKindNipMap();
+  for (const [kind, nip] of nipMap) {
+    if (!(kind in names)) {
+      names[kind] = `Kind ${kind} (${nip})`;
+    }
+  }
+  _kindNamesCache = names;
+  return _kindNamesCache;
+}
 
 export const STATUS_THRESHOLDS = {
   MIN_EVENTS: 5,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,16 @@ program
 program
   .command('scan')
   .description('Fetch and validate events from relays')
-  .option('--kinds <kinds>', 'Comma-separated list of kinds to scan (default: 0,3,10002,30023,14,15,10050,13,1059,13194,23194,23195,23196,23197,9734,9735)')
+  .option('--kinds <kinds>', 'Comma-separated list of kinds to scan (default: 16 priority kinds)')
+  .option('--all-schemas', 'Scan all kinds that have a schemata schema')
   .option('--relays <relays>', 'Comma-separated list of relay URLs')
   .option('--since <duration>', 'How far back to scan (e.g., 1h, 24h, 7d)')
   .option('--jitter <duration>', 'Max random offset added to --since for cohort diversity (default: 6h)')
   .action(async (opts) => {
+    if (opts.kinds && opts.allSchemas) {
+      console.error('Error: --kinds and --all-schemas are mutually exclusive.');
+      process.exit(1);
+    }
     try {
       await scanCommand(opts);
     } catch (err) {

--- a/src/validate/engine.ts
+++ b/src/validate/engine.ts
@@ -7,6 +7,7 @@ const require = createRequire(import.meta.url);
 
 // Load all schemas from the schemata package via require (avoids Node 22+ ESM JSON import issue)
 let schemas: Record<string, unknown> | null = null;
+let kindNipMap: Map<number, string> | null = null;
 
 function loadSchemas(): Record<string, unknown> {
   if (schemas) return schemas;
@@ -18,6 +19,7 @@ function loadSchemas(): Record<string, unknown> {
   const pkgDir = path.dirname(schemataDir);
 
   schemas = {};
+  kindNipMap = new Map();
   const nipsDir = path.join(pkgDir, 'dist', 'nips');
   if (!fs.existsSync(nipsDir)) {
     console.error(`Warning: schemata nips directory not found at ${nipsDir}`);
@@ -38,12 +40,31 @@ function loadSchemas(): Record<string, unknown> {
         if (fs.existsSync(schemaPath)) {
           const key = `kind${kindNum}Schema`;
           schemas[key] = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+          // Map kind number to NIP directory name (e.g., "nip-25" → "NIP-25")
+          const nipLabel = nipDir.replace(/^nip-/, 'NIP-');
+          kindNipMap!.set(Number(kindNum), nipLabel);
         }
       }
     }
   }
 
   return schemas;
+}
+
+/**
+ * Get all kind numbers that have a schemata schema.
+ */
+export function getAvailableKinds(): number[] {
+  loadSchemas();
+  return [...kindNipMap!.keys()].sort((a, b) => a - b);
+}
+
+/**
+ * Get mapping of kind number → NIP label (e.g., 7 → "NIP-25").
+ */
+export function getKindNipMap(): Map<number, string> {
+  loadSchemas();
+  return new Map(kindNipMap!);
 }
 
 const ajv = new Ajv({ strict: false, allErrors: true });


### PR DESCRIPTION
## Summary
- Add `--all-schemas` flag to scan all 169 kinds that have schemata schemas, replacing the hardcoded 16
- Per-kind watermarks when `--since` is not provided, so frequent kinds (e.g. kind:1) don't starve rare ones
- Lazy `getKindNames()` auto-generates human-readable names for all discovered kinds

## Changes
- `src/validate/engine.ts` — build `kindNipMap` during schema discovery; export `getAvailableKinds()` and `getKindNipMap()`
- `src/config.ts` — rename `DEFAULT_KINDS` → `PRIORITY_KINDS`, `KIND_NAMES` → `PRIORITY_KIND_NAMES`; add `getKindNames()`
- `src/index.ts` — add `--all-schemas` option (mutually exclusive with `--kinds`)
- `src/commands/scan.ts` — kind resolution logic, per-kind watermarks, estimated time logging
- `src/commands/export.ts` — use `getKindNames()` for all kind name lookups

## Default behavior unchanged
Running `sherlock scan` without flags still scans the same 16 priority kinds.

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — compiles clean
- [x] `sherlock scan --help` — shows `--all-schemas` flag
- [x] `sherlock scan --kinds 1,7 --all-schemas` — errors with mutual exclusion message
- [ ] `sherlock scan --since 1h` — default 16 kinds, same behavior as before
- [ ] `sherlock scan --all-schemas --since 1h` — scans all 169 kinds
- [ ] `sherlock export` — kind names populated for all kinds in DB

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--all-schemas` option to scan command for discovering all available kinds with schemas.
  * Implemented per-kind high-water mark tracking for more efficient incremental scans.
  * Enhanced scan output with schema coverage reporting and estimated total runtime.

* **Improvements**
  * Added validation to prevent conflicting `--kinds` and `--all-schemas` options.
  * Improved kind-name resolution in exported results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->