### PR TITLE
feat(scan): add --batch-limit to cap events per batch

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_RELAYS, PRIORITY_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE, DEFAULT_RELAY_PAUSE_MS } from '../config.js';
+import { DEFAULT_RELAYS, PRIORITY_KINDS, DEFAULT_SCAN_WINDOW_SECONDS, DEFAULT_KIND_BATCH_SIZE, DEFAULT_RELAY_PAUSE_MS, DEFAULT_BATCH_LIMIT } from '../config.js';
 import { fetchEvents, checkNak } from '../fetch/nak.js';
 import { validateEvent, checkSchemaAvailability, runSemanticChecks, getAvailableKinds } from '../validate/engine.js';
 import { resolveAttribution } from '../attribution/resolve.js';
@@ -14,6 +14,7 @@ interface ScanCommandOptions {
   relays?: string;
   since?: string;
   jitter?: string;
+  batchLimit?: string;
 }
 
 /**
@@ -89,6 +90,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     console.log(`  Events for these kinds will be stored with valid=NULL`);
   }
 
+  const batchLimit = opts.batchLimit !== undefined ? parseInt(opts.batchLimit, 10) : DEFAULT_BATCH_LIMIT;
   const sinceDate = new Date(since * 1000).toISOString();
   const numBatches = Math.ceil(kinds.length / DEFAULT_KIND_BATCH_SIZE);
   const estMinutes = Math.ceil((numBatches * 7 + DEFAULT_RELAY_PAUSE_MS / 1000) * relays.length / 60);
@@ -96,6 +98,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
   console.log(`  Kinds: ${kinds.join(', ')}`);
   console.log(`  Relays: ${relays.join(', ')} (order randomized)`);
   console.log(`  Since: ${sinceDate} (jitter: -${Math.floor(jitterApplied / 60)}m)`);
+  console.log(`  Batch limit: ${batchLimit > 0 ? formatNumber(batchLimit) + ' events/batch' : 'unlimited'}`);
   if (perKindSince) {
     console.log(`  Using per-kind watermarks (${perKindSince.size} kinds)`);
   }
@@ -133,6 +136,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
       relays,
       since,
       perKindSince,
+      batchLimit: isNaN(batchLimit) ? DEFAULT_BATCH_LIMIT : batchLimit,
       onRelayStart: (relay, index, total) => {
         console.log(`  [relay ${index + 1}/${total}] ${relay}`);
       },

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -90,7 +90,8 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
     console.log(`  Events for these kinds will be stored with valid=NULL`);
   }
 
-  const batchLimit = opts.batchLimit !== undefined ? parseInt(opts.batchLimit, 10) : DEFAULT_BATCH_LIMIT;
+  const parsedLimit = opts.batchLimit !== undefined ? Number(opts.batchLimit) : NaN;
+  const batchLimit = Number.isInteger(parsedLimit) && parsedLimit >= 0 ? parsedLimit : DEFAULT_BATCH_LIMIT;
   const sinceDate = new Date(since * 1000).toISOString();
   const numBatches = Math.ceil(kinds.length / DEFAULT_KIND_BATCH_SIZE);
   const estMinutes = Math.ceil((numBatches * 7 + DEFAULT_RELAY_PAUSE_MS / 1000) * relays.length / 60);
@@ -136,7 +137,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
       relays,
       since,
       perKindSince,
-      batchLimit: isNaN(batchLimit) ? DEFAULT_BATCH_LIMIT : batchLimit,
+      batchLimit,
       onRelayStart: (relay, index, total) => {
         console.log(`  [relay ${index + 1}/${total}] ${relay}`);
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export const DEFAULT_PAGINATE_INTERVAL = '5s';   // pause between paginated page
 export const DEFAULT_RELAY_PAUSE_MS = 3000;       // pause between sequential relay scans
 export const DEFAULT_BATCH_PAUSE_MS = 2000;       // pause between kind batches on same relay
 export const DEFAULT_KIND_BATCH_SIZE = 5;         // max kinds per REQ filter
+export const DEFAULT_BATCH_LIMIT = 5000;          // max events per nak batch (0 = unlimited)
 
 export const DB_FILENAME = 'sherlock.db';
 

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_RELAY_PAUSE_MS,
   DEFAULT_BATCH_PAUSE_MS,
   DEFAULT_KIND_BATCH_SIZE,
+  DEFAULT_BATCH_LIMIT,
 } from '../config.js';
 import type { ChildProcess } from 'node:child_process';
 import type { NostrEvent, RateLimitEvent } from '../types.js';
@@ -47,6 +48,8 @@ export interface NakFetchOptions {
   since: number;
   /** Per-kind watermarks — if provided, each batch uses the minimum since across its kinds. */
   perKindSince?: Map<number, number>;
+  /** Max events per nak batch request (passed as --limit to nak). 0 = unlimited. */
+  batchLimit?: number;
   onEvent: (event: NostrEvent, relay: string) => void;
   onError?: (error: string) => void;
   onRateLimit?: (event: RateLimitEvent) => void;
@@ -102,6 +105,7 @@ async function fetchBatchFromRelay(
   relay: string,
   kinds: number[],
   since: number,
+  batchLimit: number,
   onEvent: (event: NostrEvent, relay: string) => void,
   onError?: (error: string) => void,
   onRateLimit?: (event: RateLimitEvent) => void,
@@ -113,6 +117,9 @@ async function fetchBatchFromRelay(
   }
 
   args.push('--since', String(since));
+  if (batchLimit > 0) {
+    args.push('--limit', String(batchLimit));
+  }
   args.push('--paginate');
   args.push('--paginate-interval', DEFAULT_PAGINATE_INTERVAL);
   args.push(relay);
@@ -228,6 +235,7 @@ export async function fetchEvents(opts: NakFetchOptions): Promise<number> {
           relay,
           batch,
           batchSince,
+          opts.batchLimit ?? DEFAULT_BATCH_LIMIT,
           opts.onEvent,
           opts.onError,
           opts.onRateLimit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ program
   .option('--relays <relays>', 'Comma-separated list of relay URLs')
   .option('--since <duration>', 'How far back to scan (e.g., 1h, 24h, 7d)')
   .option('--jitter <duration>', 'Max random offset added to --since for cohort diversity (default: 6h)')
+  .option('--batch-limit <n>', 'Max events per nak batch request (default: 5000, 0 = unlimited)')
   .action(async (opts) => {
     if (opts.kinds && opts.allSchemas) {
       console.error('Error: --kinds and --all-schemas are mutually exclusive.');


### PR DESCRIPTION
## Summary
- Add `--batch-limit` flag (default: 5000) that passes `--limit N` to nak
- Prevents popular kinds (kind:1, kind:1059) from causing 20+ minute pagination
- With 169 kinds across 3 relays, estimated scan time drops from ~30min to ~10min

## Context
The first `--all-schemas` CI run hit the 30-minute timeout because kind:1 alone returned 88k events from relay.damus.io. For validation, 5000 events per batch (~1000/kind) provides plenty of statistical signal.

## Changes
- `src/config.ts` — add `DEFAULT_BATCH_LIMIT = 5000`
- `src/fetch/nak.ts` — accept `batchLimit` option, pass `--limit` to nak when > 0
- `src/commands/scan.ts` — parse and forward `--batch-limit`
- `src/index.ts` — add `--batch-limit <n>` CLI option

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `sherlock scan --help` — shows `--batch-limit` flag
- [ ] `sherlock scan --all-schemas --since 1h` — completes within ~10 min
- [ ] `sherlock scan --batch-limit 0 --since 1h` — unlimited (old behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--batch-limit` CLI option to the scan command to control max events per batch (default 5,000; `0` = unlimited).
  * Scan output now logs the effective batch setting (shows "unlimited" or formatted "events/batch") so you can confirm runtime batching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->