### PR TITLE
feat(scan): solo batches for high-volume kinds, lower limit to 2500

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,10 @@ export const DEFAULT_PAGINATE_INTERVAL = '5s';   // pause between paginated page
 export const DEFAULT_RELAY_PAUSE_MS = 3000;       // pause between sequential relay scans
 export const DEFAULT_BATCH_PAUSE_MS = 2000;       // pause between kind batches on same relay
 export const DEFAULT_KIND_BATCH_SIZE = 5;         // max kinds per REQ filter
-export const DEFAULT_BATCH_LIMIT = 5000;          // max events per nak batch (0 = unlimited)
+export const DEFAULT_BATCH_LIMIT = 2500;          // max events per nak batch (0 = unlimited)
+
+// High-volume kinds that get their own solo batch to avoid starving other kinds
+export const HIGH_VOLUME_KINDS = [1];
 
 export const DB_FILENAME = 'sherlock.db';
 

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -202,8 +202,9 @@ export async function fetchEvents(opts: NakFetchOptions): Promise<number> {
 
   // Separate high-volume kinds into solo batches so they don't starve others
   const highVolume = new Set(HIGH_VOLUME_KINDS);
-  const soloKinds = opts.kinds.filter(k => highVolume.has(k));
-  const normalKinds = opts.kinds.filter(k => !highVolume.has(k));
+  const uniqueKinds = [...new Set(opts.kinds)];
+  const soloKinds = uniqueKinds.filter(k => highVolume.has(k));
+  const normalKinds = uniqueKinds.filter(k => !highVolume.has(k));
   const kindBatches = shuffle([
     ...soloKinds.map(k => [k]),
     ...chunk(normalKinds, DEFAULT_KIND_BATCH_SIZE),

--- a/src/fetch/nak.ts
+++ b/src/fetch/nak.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_BATCH_PAUSE_MS,
   DEFAULT_KIND_BATCH_SIZE,
   DEFAULT_BATCH_LIMIT,
+  HIGH_VOLUME_KINDS,
 } from '../config.js';
 import type { ChildProcess } from 'node:child_process';
 import type { NostrEvent, RateLimitEvent } from '../types.js';
@@ -199,8 +200,14 @@ export async function fetchEvents(opts: NakFetchOptions): Promise<number> {
   // Shuffle relay order so we don't always hit the same one first
   const relays = shuffle([...opts.relays]);
 
-  // Shuffle kind batches for sampling diversity
-  const kindBatches = shuffle(chunk([...opts.kinds], DEFAULT_KIND_BATCH_SIZE));
+  // Separate high-volume kinds into solo batches so they don't starve others
+  const highVolume = new Set(HIGH_VOLUME_KINDS);
+  const soloKinds = opts.kinds.filter(k => highVolume.has(k));
+  const normalKinds = opts.kinds.filter(k => !highVolume.has(k));
+  const kindBatches = shuffle([
+    ...soloKinds.map(k => [k]),
+    ...chunk(normalKinds, DEFAULT_KIND_BATCH_SIZE),
+  ]);
 
   let totalCount = 0;
 


### PR DESCRIPTION
## Summary
- kind:1 (text notes) now gets its own solo batch so it can't starve other kinds of the event budget
- Default batch limit lowered from 5000 to 2500 (~500 events/kind is plenty for validation)
- `HIGH_VOLUME_KINDS` array in config makes it easy to add more solo kinds later

## Changes
- `src/config.ts` — `DEFAULT_BATCH_LIMIT` 5000 → 2500, add `HIGH_VOLUME_KINDS = [1]`
- `src/fetch/nak.ts` — split kinds into solo (high-volume) and normal batches before shuffling

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [ ] `sherlock scan --all-schemas --since 1h` — kind:1 appears alone in its batch log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced the maximum events per NAK batch to lower peak processing load.
  * Added a dedicated solo-batching strategy for identified high-volume event types to improve throughput and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->