### PR TITLE
feat(export): write data/summary.json alongside findings.json

### DIFF
--- a/data/summary.json
+++ b/data/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_events": 62,
+  "total_valid": 58,
+  "total_invalid": 4,
+  "kinds_scanned_count": 3,
+  "apps_identified": 6,
+  "generated_at": "2026-03-26T17:16:41.764Z"
+}

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -820,6 +820,19 @@ export async function exportCommand(opts: ExportCommandOptions): Promise<void> {
   writeFileSync(jsonPath, JSON.stringify(findings, null, 2) + '\n');
   console.log(`  Wrote ${jsonPath}`);
 
+  // Write summary (tiny subset for dashboard consumption)
+  const summaryPath = resolve(outdir, 'data', 'summary.json');
+  const summary = {
+    total_events: findings.scan_coverage.total_events,
+    total_valid: findings.scan_coverage.total_valid,
+    total_invalid: findings.scan_coverage.total_invalid,
+    kinds_scanned_count: findings.scan_coverage.kinds_scanned.length,
+    apps_identified: Object.keys(findings.by_app).length,
+    generated_at: findings.generated_at,
+  };
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+  console.log(`  Wrote ${summaryPath}`);
+
   // Write HTML
   const htmlPath = resolve(outdir, 'docs', 'index.html');
   mkdirSync(dirname(htmlPath), { recursive: true });


### PR DESCRIPTION
## Summary
- Writes a ~150B `data/summary.json` alongside the 7MB `findings.json` during export
- Contains `total_events`, `total_valid`, `total_invalid`, `kinds_scanned_count` (integer), `apps_identified`, `generated_at`
- No new DB queries — extracts from the already-built findings object
- CI already includes `data/summary.json` in the git-add step

## Motivation
The nostrability dashboard currently downloads the full 7MB `findings.json` just to read two numbers. This provides a tiny alternative.

## Test plan
- [x] `npm run build && node dist/index.js export` succeeds
- [x] `data/summary.json` is <1KB with correct values
- [ ] CI scan workflow commits `summary.json` alongside `findings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)