### PR TITLE
feat(export): add error rate to dashboard summary bar

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -487,10 +487,15 @@ function copyText(text) { navigator.clipboard.writeText(text); }
     var d = Math.floor(h / 24);
     return d + 'd ago';
   }
+  var validated = c.total_valid + c.total_invalid;
+  var errorRateNum = validated > 0 ? (c.total_invalid / validated * 100) : 0;
+  var errorRate = errorRateNum.toFixed(1);
+  var erColor = errorRateNum === 0 ? '#58d68d' : errorRateNum <= 5 ? '#f4d03f' : '#e74c3c';
   document.getElementById('coverage').innerHTML = [
     stat('Events', c.total_events.toLocaleString()),
     stat('Valid', c.total_valid.toLocaleString()),
     stat('Invalid', c.total_invalid.toLocaleString()),
+    stat('Error Rate', '<span style="color:' + erColor + '">' + errorRate + '%</span>'),
     stat('No Schema', c.total_no_schema.toLocaleString()),
     stat('Kinds', c.kinds_scanned.length),
     stat('Relays', c.relays.length),


### PR DESCRIPTION
## Summary
- Add a color-coded **Error Rate** percentage to the Sherlock HTML dashboard's top coverage bar
- Computed as `total_invalid / (total_valid + total_invalid) * 100`
- Color coding: green (0%), yellow (≤5%), red (>5%)

## Test plan
- [ ] Run `sherlock export` and verify the Error Rate stat appears between Invalid and No Schema
- [ ] Verify color coding: green when 0%, yellow when ≤5%, red when >5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Error Rate metric tile to the HTML coverage dashboard with color-coded indicators based on the calculated rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->