### PR TITLE
Reduce DB bloat, fix CI timeout, add reattribute command

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: write
 

--- a/src/commands/reattribute.ts
+++ b/src/commands/reattribute.ts
@@ -1,0 +1,65 @@
+import { extractClientTag } from '../attribution/client-tag.js';
+import { getDb } from '../db/index.js';
+import { formatNumber } from '../util.js';
+
+/**
+ * Re-run Tier 1 (client tag) attribution on existing unattributed events.
+ * Scans events where client_name IS NULL and raw JSON is available,
+ * parses tags, and updates attribution columns in place.
+ */
+export function reattributeCommand(): void {
+  const db = getDb();
+
+  // Find unattributed events that still have raw JSON stored
+  const rows = db.prepare(`
+    SELECT id, raw FROM events
+    WHERE client_name IS NULL AND raw != '' AND raw IS NOT NULL
+  `).all() as Array<{ id: string; raw: string }>;
+
+  console.log(`Found ${formatNumber(rows.length)} unattributed events with stored raw JSON`);
+
+  if (rows.length === 0) {
+    console.log('Nothing to reattribute.');
+    return;
+  }
+
+  const update = db.prepare(`
+    UPDATE events
+    SET client_name = ?, attribution_method = 'client_tag', attribution_confidence = 'high'
+    WHERE id = ?
+  `);
+
+  let attributed = 0;
+  let parsed = 0;
+  let parseErrors = 0;
+
+  const txn = db.transaction(() => {
+    for (const row of rows) {
+      let tags: string[][];
+      try {
+        const event = JSON.parse(row.raw);
+        tags = event.tags;
+        parsed++;
+      } catch {
+        parseErrors++;
+        continue;
+      }
+
+      if (!Array.isArray(tags)) continue;
+
+      const client = extractClientTag(tags);
+      if (client) {
+        update.run(client.name, row.id);
+        attributed++;
+      }
+    }
+  });
+
+  txn();
+
+  console.log(`\nResults:`);
+  console.log(`  Parsed:      ${formatNumber(parsed)}`);
+  console.log(`  Parse errors: ${formatNumber(parseErrors)}`);
+  console.log(`  Attributed:  ${formatNumber(attributed)}`);
+  console.log(`  Still unattributed: ${formatNumber(rows.length - attributed - parseErrors)}`);
+}

--- a/src/commands/reattribute.ts
+++ b/src/commands/reattribute.ts
@@ -61,5 +61,5 @@ export function reattributeCommand(): void {
   console.log(`  Parsed:      ${formatNumber(parsed)}`);
   console.log(`  Parse errors: ${formatNumber(parseErrors)}`);
   console.log(`  Attributed:  ${formatNumber(attributed)}`);
-  console.log(`  Still unattributed: ${formatNumber(rows.length - attributed - parseErrors)}`);
+  console.log(`  Still unattributed: ${formatNumber(rows.length - attributed)}`);
 }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -177,7 +177,7 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
         // Only persist full raw JSON for events we'll drill into:
         // invalid events (debugging) or attributed events (training data).
         // Valid unattributed events still get a DB row, just with empty raw.
-        const keepRaw = !validation.valid || attribution !== null;
+        const keepRaw = validation.valid === false || attribution !== null;
         const rawJson = keepRaw ? JSON.stringify(event) : '';
 
         const isNew = storeEvent(event, validation, null, relay, scanRunId, attribution, rawJson);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -173,7 +173,14 @@ export async function scanCommand(opts: ScanCommandOptions): Promise<void> {
         }
 
         const attribution = resolveAttribution(event, nip89Map, fingerprints);
-        const isNew = storeEvent(event, validation, null, relay, scanRunId, attribution);
+
+        // Only persist full raw JSON for events we'll drill into:
+        // invalid events (debugging) or attributed events (training data).
+        // Valid unattributed events still get a DB row, just with empty raw.
+        const keepRaw = !validation.valid || attribution !== null;
+        const rawJson = keepRaw ? JSON.stringify(event) : '';
+
+        const isNew = storeEvent(event, validation, null, relay, scanRunId, attribution, rawJson);
 
         if (!isNew) {
           progress.duplicates++;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -121,6 +121,7 @@ function getInsertViolation() {
 /**
  * Insert an event and its violations in a single transaction.
  * Returns true if the event was new (inserted), false if duplicate.
+ * `raw` is the full JSON string — caller decides whether to persist it or pass ''.
  */
 export function storeEvent(
   event: NostrEvent,
@@ -129,8 +130,9 @@ export function storeEvent(
   sourceRelay?: string,
   scanRunId?: number,
   attribution?: Attribution | null,
+  raw?: string,
 ): boolean {
-  const raw = JSON.stringify(event);
+  const rawJson = raw ?? JSON.stringify(event);
   const validValue = validation.valid === null ? null : validation.valid ? 1 : 0;
 
   const txn = getDb().transaction(() => {
@@ -140,7 +142,7 @@ export function storeEvent(
       kind: event.kind,
       created_at: event.created_at,
       tags: JSON.stringify(event.tags),
-      raw,
+      raw: rawJson,
       client_name: attribution?.name ?? client?.name ?? null,
       source_relay: sourceRelay ?? null,
       valid: validValue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { scanCommand } from './commands/scan.js';
 import { reportCommand } from './commands/report.js';
 import { statsCommand } from './commands/stats.js';
 import { exportCommand } from './commands/export.js';
+import { reattributeCommand } from './commands/reattribute.js';
 import { closeDb } from './db/index.js';
 
 const program = new Command();
@@ -79,6 +80,20 @@ program
       await exportCommand(opts);
     } catch (err) {
       console.error('Export failed:', err);
+      process.exit(1);
+    } finally {
+      closeDb();
+    }
+  });
+
+program
+  .command('reattribute')
+  .description('Re-run Tier 1 attribution on unattributed events with stored raw JSON')
+  .action(() => {
+    try {
+      reattributeCommand();
+    } catch (err) {
+      console.error('Reattribute failed:', err);
       process.exit(1);
     } finally {
       closeDb();


### PR DESCRIPTION
## Summary
- **Don't store raw JSON for valid unattributed events** — only persist full JSON blobs for invalid events (debugging) and attributed events (training data). Valid events without client tags get `raw = ''`. All rows/stats/counts preserved. Estimated ~350-400 MB savings per scan cycle (~1.2 GB → ~300 MB).
- **Increase CI timeout from 60 to 90 minutes** — safety margin for large DB artifact uploads that were pushing close to the limit.
- **Add `reattribute` command** — retroactively re-runs Tier 1 (client tag) attribution on existing unattributed events that have stored raw JSON. Targets the ~26K unattributed events in the current DB.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run build` succeeds (verified locally)
- [ ] `node dist/index.js scan --since 1h --kinds 10002,3` — verify valid events get empty raw, invalid/attributed events get full raw
- [ ] `node dist/index.js reattribute` on CI database — check how many events gain attribution
- [ ] Next CI run completes well under 90 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to re-run attribution for previously unattributed events.

* **Chores**
  * Increased scan workflow timeout from 60 to 90 minutes.
  * Adjusted event storage so raw JSON is retained only for invalid events or those that are attributed, reducing raw payloads for other events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->